### PR TITLE
fix: voice-check 500 from fenced/prose sidecar JSON (#45)

### DIFF
--- a/src/PBA.Application/Features/Content/Queries/CheckVoice.cs
+++ b/src/PBA.Application/Features/Content/Queries/CheckVoice.cs
@@ -46,9 +46,14 @@ public static class CheckVoice
         {
             score = 0;
             feedback = string.Empty;
+
+            var json = ExtractJsonObject(response);
+            if (json is null)
+                return false;
+
             try
             {
-                using var doc = JsonDocument.Parse(response);
+                using var doc = JsonDocument.Parse(json);
                 if (!doc.RootElement.TryGetProperty("score", out var scoreProp) ||
                     !doc.RootElement.TryGetProperty("feedback", out var feedbackProp))
                     return false;
@@ -60,6 +65,22 @@ public static class CheckVoice
             {
                 return false;
             }
+        }
+
+        // LLMs frequently wrap the JSON object in markdown fences or surrounding
+        // prose ("Here is the analysis: {...}"). Extract the outermost object so
+        // JsonDocument.Parse sees only the braces, not the chatter around them.
+        private static string? ExtractJsonObject(string response)
+        {
+            if (string.IsNullOrWhiteSpace(response))
+                return null;
+
+            var start = response.IndexOf('{');
+            var end = response.LastIndexOf('}');
+            if (start < 0 || end <= start)
+                return null;
+
+            return response[start..(end + 1)];
         }
 
         private static string BuildSystemPrompt(Domain.Entities.BrandProfile? profile)

--- a/tests/PBA.Application.Tests/Features/Content/Queries/CheckVoiceHandlerTests.cs
+++ b/tests/PBA.Application.Tests/Features/Content/Queries/CheckVoiceHandlerTests.cs
@@ -132,6 +132,46 @@ public class CheckVoiceHandlerTests
     }
 
     [Fact]
+    public async Task Handle_SidecarWrapsJsonInMarkdownFence_ReturnsScore()
+    {
+        await using var context = CreateContext();
+        var content = new ContentEntity { Title = "Test", Body = "Some body" };
+        context.Contents.Add(content);
+        await context.SaveChangesAsync();
+
+        _sidecarMock
+            .Setup(s => s.SendPromptAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("```json\n{\"score\": 82, \"feedback\": \"Strong match\"}\n```");
+
+        var handler = new CheckVoice.Handler(context, _sidecarMock.Object);
+        var result = await handler.Handle(new CheckVoice.Query(content.Id), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(82m, result.Value!.Score);
+        Assert.Equal("Strong match", result.Value.Feedback);
+    }
+
+    [Fact]
+    public async Task Handle_SidecarAddsProseAroundJson_ReturnsScore()
+    {
+        await using var context = CreateContext();
+        var content = new ContentEntity { Title = "Test", Body = "Some body" };
+        context.Contents.Add(content);
+        await context.SaveChangesAsync();
+
+        _sidecarMock
+            .Setup(s => s.SendPromptAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("Here is my analysis:\n{\"score\": 64, \"feedback\": \"Decent\"}\nLet me know if you need more.");
+
+        var handler = new CheckVoice.Handler(context, _sidecarMock.Object);
+        var result = await handler.Handle(new CheckVoice.Query(content.Id), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(64m, result.Value!.Score);
+        Assert.Equal("Decent", result.Value.Feedback);
+    }
+
+    [Fact]
     public async Task Handle_ScoreOutOfRange_ReturnsFailure()
     {
         await using var context = CreateContext();


### PR DESCRIPTION
## Summary
Fixes #45. `GET /api/content/{id}/voice-check` returned **HTTP 500** with `Sidecar returned invalid voice check response` because the OpenRouter sidecar (gemini-2.5-pro) wraps the voice-check JSON in markdown fences or surrounding prose. The handler called `JsonDocument.Parse` on the raw response, which threw, and `TryParseVoiceResponse` returned false.

## Fix
Added `ExtractJsonObject` to `CheckVoice.Handler` — slices the outermost `{ ... }` out of the response before parsing, so fences/prose are ignored. No-brace responses still fall through to the existing failure path.

## Tests
- `Handle_SidecarWrapsJsonInMarkdownFence_ReturnsScore` (new, was RED)
- `Handle_SidecarAddsProseAroundJson_ReturnsScore` (new, was RED)
- All 312 `PBA.Application.Tests` green.

## Open question (deferred)
Issue #45 asks to confirm the score scale (0–1 vs 0–100) the sidecar actually returns. The prompt requests 0–100 and the range check enforces it; the frontend normalizes defensively. Confirming the real scale needs a live sidecar call — not done here. The 500 is fixed regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)