### PR TITLE
fix: newsfeed not ingesting TLDR/Medium daily articles

### DIFF
--- a/src/PBA.Application/Common/Interfaces/IRssFeedReader.cs
+++ b/src/PBA.Application/Common/Interfaces/IRssFeedReader.cs
@@ -2,5 +2,5 @@ namespace PBA.Application.Common.Interfaces;
 
 public interface IRssFeedReader
 {
-    Task<List<RssFeedItem>> ReadFeedAsync(string feedUrl, DateTimeOffset? since, CancellationToken ct = default);
+    Task<List<RssFeedItem>> ReadFeedAsync(string feedUrl, CancellationToken ct = default);
 }

--- a/src/PBA.Application/Features/Ideas/Commands/RefreshIdeaSources.cs
+++ b/src/PBA.Application/Features/Ideas/Commands/RefreshIdeaSources.cs
@@ -30,7 +30,7 @@ public static class RefreshIdeaSources
                 try
                 {
                     var entries = await feedReader.ReadFeedAsync(
-                        source.FeedUrl!, source.LastPolledAt, cancellationToken);
+                        source.FeedUrl!, cancellationToken);
 
                     foreach (var entry in entries)
                     {

--- a/src/PBA.Application/Features/Ideas/Commands/RefreshIdeaSources.cs
+++ b/src/PBA.Application/Features/Ideas/Commands/RefreshIdeaSources.cs
@@ -52,6 +52,7 @@ public static class RefreshIdeaSources
                             ThumbnailUrl = entry.ThumbnailUrl,
                             Category = entry.Category ?? source.Category,
                             Status = IdeaStatus.New,
+                            DetectedAt = entry.PublishedAt,
                             DeduplicationKey = dedupKey
                         });
 

--- a/src/PBA.Infrastructure/Services/RssFeedReader.cs
+++ b/src/PBA.Infrastructure/Services/RssFeedReader.cs
@@ -17,7 +17,7 @@ public class RssFeedReader : IRssFeedReader
     }
 
     public async Task<List<RssFeedItem>> ReadFeedAsync(
-        string feedUrl, DateTimeOffset? since, CancellationToken ct = default)
+        string feedUrl, CancellationToken ct = default)
     {
         using var stream = await _httpClient.GetStreamAsync(feedUrl, ct);
         using var xmlReader = XmlReader.Create(stream, new XmlReaderSettings { Async = true });
@@ -35,9 +35,6 @@ public class RssFeedReader : IRssFeedReader
                     ? item.LastUpdatedTime
                     : DateTimeOffset.UtcNow).ToUniversalTime();
 
-            if (since.HasValue && published <= since.Value)
-                continue;
-
             var url = item.Links.FirstOrDefault()?.Uri?.AbsoluteUri;
             var description = item.Summary?.Text;
             var thumbnail = GetThumbnailUrl(item);
@@ -52,8 +49,7 @@ public class RssFeedReader : IRssFeedReader
                 published));
         }
 
-        _logger.LogDebug("Read {Count} items from {FeedUrl} (since {Since})",
-            items.Count, feedUrl, since);
+        _logger.LogDebug("Read {Count} items from {FeedUrl}", items.Count, feedUrl);
 
         return items;
     }

--- a/src/PBA.Infrastructure/Services/RssPollingService.cs
+++ b/src/PBA.Infrastructure/Services/RssPollingService.cs
@@ -75,7 +75,7 @@ public class RssPollingService : BackgroundService
         {
             try
             {
-                var entries = await feedReader.ReadFeedAsync(source.FeedUrl!, source.LastPolledAt, ct);
+                var entries = await feedReader.ReadFeedAsync(source.FeedUrl!, ct);
 
                 var newCount = 0;
                 foreach (var entry in entries)

--- a/tests/PBA.Application.Tests/Features/Ideas/Commands/RefreshIdeaSourcesHandlerTests.cs
+++ b/tests/PBA.Application.Tests/Features/Ideas/Commands/RefreshIdeaSourcesHandlerTests.cs
@@ -31,7 +31,7 @@ public class RefreshIdeaSourcesHandlerTests
         await db.SaveChangesAsync();
 
         var mockReader = new Mock<IRssFeedReader>();
-        mockReader.Setup(r => r.ReadFeedAsync(It.IsAny<string>(), It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()))
+        mockReader.Setup(r => r.ReadFeedAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<RssFeedItem>());
 
         var handler = new RefreshIdeaSources.Handler(
@@ -40,7 +40,7 @@ public class RefreshIdeaSourcesHandlerTests
         await handler.Handle(new RefreshIdeaSources.Command(), CancellationToken.None);
 
         mockReader.Verify(r => r.ReadFeedAsync(
-            It.IsAny<string>(), It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()),
+            It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Exactly(2));
     }
 
@@ -60,7 +60,7 @@ public class RefreshIdeaSourcesHandlerTests
         };
 
         var mockReader = new Mock<IRssFeedReader>();
-        mockReader.Setup(r => r.ReadFeedAsync(source.FeedUrl!, It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()))
+        mockReader.Setup(r => r.ReadFeedAsync(source.FeedUrl!, It.IsAny<CancellationToken>()))
             .ReturnsAsync(items);
 
         var handler = new RefreshIdeaSources.Handler(
@@ -83,9 +83,9 @@ public class RefreshIdeaSourcesHandlerTests
         await db.SaveChangesAsync();
 
         var mockReader = new Mock<IRssFeedReader>();
-        mockReader.Setup(r => r.ReadFeedAsync(failSource.FeedUrl!, It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()))
+        mockReader.Setup(r => r.ReadFeedAsync(failSource.FeedUrl!, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("Connection refused"));
-        mockReader.Setup(r => r.ReadFeedAsync(okSource.FeedUrl!, It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()))
+        mockReader.Setup(r => r.ReadFeedAsync(okSource.FeedUrl!, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<RssFeedItem>
             {
                 new("Good Article", "Desc", "https://working.com/good", null, "OK", DateTimeOffset.UtcNow),

--- a/tests/PBA.Application.Tests/Features/Ideas/Commands/RefreshIdeaSourcesHandlerTests.cs
+++ b/tests/PBA.Application.Tests/Features/Ideas/Commands/RefreshIdeaSourcesHandlerTests.cs
@@ -74,6 +74,34 @@ public class RefreshIdeaSourcesHandlerTests
     }
 
     [Fact]
+    public async Task Handle_SetsDetectedAt_FromFeedPublishDate()
+    {
+        // Regression: refresh used to omit DetectedAt, so items defaulted to
+        // 0001-01-01 and sank to the bottom of the DetectedAt-sorted feed —
+        // ingested but invisible. Must carry the feed's publish date like the poller.
+        using var db = CreateContext();
+        var source = new IdeaSource { Name = "Source", Category = "Tech", IsEnabled = true, FeedUrl = "https://blog.com/rss" };
+        db.IdeaSources.Add(source);
+        await db.SaveChangesAsync();
+
+        var published = new DateTimeOffset(2026, 6, 3, 0, 0, 0, TimeSpan.Zero);
+        var mockReader = new Mock<IRssFeedReader>();
+        mockReader.Setup(r => r.ReadFeedAsync(source.FeedUrl!, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<RssFeedItem>
+            {
+                new("Today's Story", "Desc", "https://blog.com/today", null, "Tech", published),
+            });
+
+        var handler = new RefreshIdeaSources.Handler(
+            db, mockReader.Object, NullLogger<RefreshIdeaSources.Handler>.Instance);
+
+        await handler.Handle(new RefreshIdeaSources.Command(), CancellationToken.None);
+
+        var idea = await db.Ideas.SingleAsync();
+        Assert.Equal(published, idea.DetectedAt);
+    }
+
+    [Fact]
     public async Task Handle_HandlesFeedErrors_GracefullyPerSource()
     {
         using var db = CreateContext();

--- a/tests/PBA.Infrastructure.Tests/Services/RssFeedReaderTests.cs
+++ b/tests/PBA.Infrastructure.Tests/Services/RssFeedReaderTests.cs
@@ -1,0 +1,54 @@
+using System.Net;
+using System.Text;
+using Microsoft.Extensions.Logging.Abstractions;
+using PBA.Infrastructure.Services;
+using Xunit;
+
+namespace PBA.Infrastructure.Tests.Services;
+
+public class RssFeedReaderTests
+{
+    private const string FeedWithBackdatedItem = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0">
+          <channel>
+            <title>TLDR Tech Feed</title>
+            <item>
+              <title>Today's Story</title>
+              <link>https://example.com/todays-story</link>
+              <description>A fresh story stamped at midnight.</description>
+              <pubDate>Wed, 03 Jun 2026 00:00:00 GMT</pubDate>
+            </item>
+          </channel>
+        </rss>
+        """;
+
+    private static RssFeedReader CreateReader(string xml) =>
+        new(new HttpClient(new StubHandler(xml)), NullLogger<RssFeedReader>.Instance);
+
+    [Fact]
+    public async Task ReadFeedAsync_ReturnsItemsPublishedBeforeNow()
+    {
+        // Regression: TLDR (and the bullrich.dev proxy) stamps every story in a daily
+        // issue with pubDate = 00:00:00 of the issue day. The old `published <= since`
+        // filter, fed by LastPolledAt (always "earlier today"), dropped every such item,
+        // so no TLDR/Medium ideas were ingested after the first poll. Dedup — not a
+        // poll-time watermark — is what prevents re-adds, so the reader must return the
+        // item regardless of when we last polled.
+        var reader = CreateReader(FeedWithBackdatedItem);
+
+        var items = await reader.ReadFeedAsync("https://example.com/feed");
+
+        Assert.Contains(items, i => i.Url == "https://example.com/todays-story");
+    }
+
+    private sealed class StubHandler(string xml) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(xml, Encoding.UTF8, "application/rss+xml"),
+            });
+    }
+}

--- a/tests/PBA.Infrastructure.Tests/Services/RssPollingServiceTests.cs
+++ b/tests/PBA.Infrastructure.Tests/Services/RssPollingServiceTests.cs
@@ -75,7 +75,7 @@ public class RssPollingServiceTests : IDisposable
     public async Task PollAsync_CreatesIdeasForNewEntries()
     {
         var source = AddRssSource();
-        _mockReader.Setup(r => r.ReadFeedAsync(source.FeedUrl!, It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()))
+        _mockReader.Setup(r => r.ReadFeedAsync(source.FeedUrl!, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<RssFeedItem>
             {
                 new("Article 1", "Content", "https://testblog.com/article-1", null, "tech", DateTimeOffset.UtcNow),
@@ -105,7 +105,7 @@ public class RssPollingServiceTests : IDisposable
         });
         _dbContext.SaveChanges();
 
-        _mockReader.Setup(r => r.ReadFeedAsync(source.FeedUrl!, It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()))
+        _mockReader.Setup(r => r.ReadFeedAsync(source.FeedUrl!, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<RssFeedItem>
             {
                 new("Existing", "Content", "https://testblog.com/existing", null, null, DateTimeOffset.UtcNow),
@@ -123,7 +123,7 @@ public class RssPollingServiceTests : IDisposable
     public async Task PollAsync_UpdatesSourceTimestampsOnSuccess()
     {
         var source = AddRssSource();
-        _mockReader.Setup(r => r.ReadFeedAsync(source.FeedUrl!, It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()))
+        _mockReader.Setup(r => r.ReadFeedAsync(source.FeedUrl!, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<RssFeedItem>());
 
         var service = CreateService();
@@ -138,7 +138,7 @@ public class RssPollingServiceTests : IDisposable
     public async Task PollAsync_ResetsConsecutiveFailuresOnSuccess()
     {
         var source = AddRssSource(failures: 3);
-        _mockReader.Setup(r => r.ReadFeedAsync(source.FeedUrl!, It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()))
+        _mockReader.Setup(r => r.ReadFeedAsync(source.FeedUrl!, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<RssFeedItem>());
 
         var service = CreateService();
@@ -153,7 +153,7 @@ public class RssPollingServiceTests : IDisposable
     public async Task PollAsync_IncrementsFailuresOnError()
     {
         var source = AddRssSource();
-        _mockReader.Setup(r => r.ReadFeedAsync(source.FeedUrl!, It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()))
+        _mockReader.Setup(r => r.ReadFeedAsync(source.FeedUrl!, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("Connection refused"));
 
         var service = CreateService();
@@ -168,7 +168,7 @@ public class RssPollingServiceTests : IDisposable
     public async Task PollAsync_DisablesSourceAfterMaxFailures()
     {
         var source = AddRssSource(failures: 4);
-        _mockReader.Setup(r => r.ReadFeedAsync(source.FeedUrl!, It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()))
+        _mockReader.Setup(r => r.ReadFeedAsync(source.FeedUrl!, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("Timeout"));
 
         var service = CreateService();
@@ -187,7 +187,7 @@ public class RssPollingServiceTests : IDisposable
         var service = CreateService();
         await service.PollAsync(CancellationToken.None);
 
-        _mockReader.Verify(r => r.ReadFeedAsync(It.IsAny<string>(), It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()), Times.Never);
+        _mockReader.Verify(r => r.ReadFeedAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem
TLDR and Medium articles stopped appearing in the feed after ~May 20. Polling ran every 30 min with zero failures, yet no new ideas landed.

## Root causes (two compounding bugs)

**1. Backdated items filtered out (`RssFeedReader`)**
Items were dropped where `published <= LastPolledAt`. TLDR stamps every daily issue at `00:00:00 GMT`, always older than "last poll today," so issues were silently discarded after a source's first poll (when `LastPolledAt` was null). Dedup by URL+title already prevents re-adds, so the poll-time watermark was redundant and wrong. Removed the filter and the now-dead `since` param from `IRssFeedReader` and both callers.

**2. Refreshed items had no `DetectedAt`**
`RefreshIdeaSources` created ideas without `DetectedAt`, defaulting them to `0001-01-01` so they sorted to the bottom of the date-ordered feed — ingested but invisible. Now carries `entry.PublishedAt` like the poller.

## Test plan
- Failing tests written first for both bugs, then made green.
- `RssFeedReaderTests`: backdated item is now returned.
- `RefreshIdeaSourcesHandlerTests`: `DetectedAt` set from feed publish date.
- Infrastructure 263 + Application 313 tests pass; solution builds 0 warnings.
- Deployed to Mac Mini, cleaned 4,232 undated rows, re-refreshed → feed API now returns June-dated items at top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)