### PR TITLE
Merge v2-rebuild: external API, Microsoft daily brief, feed-ranking prod stack

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -43,6 +43,9 @@ services:
       # Drafting engine: OpenRouter (OpenAI-compatible). Model switchable via OPENROUTER_MODEL.
       OpenRouter__ApiKey: ${OPENROUTER_API_KEY}
       OpenRouter__Model: ${OPENROUTER_MODEL:-google/gemini-2.5-pro}
+      # Feed-ranking LLM scoring gate (section-12). Default false (no token spend); set
+      # IDEA_SCORING_ENABLED=true in a host's .env to enable per-host. Irreversible once on.
+      IdeaScoring__ScoringEnabled: ${IDEA_SCORING_ENABLED:-false}
       # Hero image generation via self-hosted ComfyUI (disabled until BaseUrl + workflow JSON supplied)
       ComfyUi__Enabled: ${COMFYUI_ENABLED:-false}
       ComfyUi__BaseUrl: ${COMFYUI_BASE_URL:-http://localhost:8188}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,58 @@
+# Production overlay for the Mac Mini deployment.
+#
+# Run with the base file, NOT the dev override:
+#   docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+# On the Mac Mini this is pinned via COMPOSE_FILE in .env, so a bare
+# `docker compose up -d` (and reboots) always uses base + prod.
+#
+# vs docker-compose.override.yml (local dev): web is the real nginx build (not
+# ng serve), the API runs in Production, no source mounts, no dev-only ports.
+services:
+  web:
+    build:
+      context: src/PersonalBrandAssistant.Web
+      dockerfile: Dockerfile          # nginx multi-stage prod build (serves SPA + proxies /api, /hubs)
+    ports:
+      - "4201:80"                     # Tailscale serve routes / -> localhost:4201
+
+  api:
+    environment:
+      ASPNETCORE_ENVIRONMENT: Production
+      # Blog publishing: in-container `git push` to the matthewkruczek-ai repo.
+      BlogConnector__RepoPath: /app/blog-repo
+      BlogConnector__Author: Matthew Kruczek
+      GIT_SSH_COMMAND: "ssh -i /app/secrets/mk_ai_deploy -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/gh_known_hosts"
+      # Multi-platform publishing (binds LinkedInOptions "Publishing:LinkedIn").
+      Publishing__LinkedIn__Enabled: "true"
+      Publishing__LinkedIn__ClientId: ${LINKEDIN_CLIENT_ID:-}
+      Publishing__LinkedIn__ClientSecret: ${LINKEDIN_CLIENT_SECRET:-}
+      Publishing__LinkedIn__RedirectUri: ${LINKEDIN_REDIRECT_URI:-http://localhost:5001/api/auth/linkedin/callback}
+      PlatformIntegrations__Reddit__ClientId: ${REDDIT_CLIENT_ID:-}
+      PlatformIntegrations__Reddit__ClientSecret: ${REDDIT_CLIENT_SECRET:-}
+      PlatformIntegrations__Reddit__Username: ${REDDIT_USERNAME:-}
+      PlatformIntegrations__Reddit__Password: ${REDDIT_PASSWORD:-}
+      PlatformIntegrations__Reddit__UserAgent: ${REDDIT_USER_AGENT:-pba/1.0}
+      PlatformIntegrations__LinkedIn__ClientId: ${LINKEDIN_CLIENT_ID:-}
+      PlatformIntegrations__LinkedIn__ClientSecret: ${LINKEDIN_CLIENT_SECRET:-}
+      # OAuth callback URLs: preserved from prior config. Updating to the Tailscale
+      # host requires registering matching redirect URIs in each platform's app first.
+      PlatformIntegrations__Twitter__CallbackUrl: http://localhost:4201/platforms/twitter/callback
+      PlatformIntegrations__LinkedIn__CallbackUrl: http://localhost:4201/platforms/linkedin/callback
+      PlatformIntegrations__Instagram__CallbackUrl: http://localhost:4201/platforms/instagram/callback
+      PlatformIntegrations__YouTube__CallbackUrl: http://localhost:4201/platforms/youtube/callback
+      GoogleAnalytics__CredentialsPath: /app/secrets/google-analytics-sa.json
+      Encryption__Key: ${Encryption__Key}
+      # Drafting engine (OpenRouter, OpenAI-compatible).
+      OpenRouter__ApiKey: ${OPENROUTER_API_KEY}
+      OpenRouter__Model: ${OPENROUTER_MODEL:-google/gemini-2.5-pro}
+      # Hero image generation via self-hosted ComfyUI.
+      ComfyUi__Enabled: ${COMFYUI_ENABLED:-false}
+      ComfyUi__BaseUrl: ${COMFYUI_BASE_URL:-http://localhost:8188}
+      ComfyUi__WorkflowPath: ${COMFYUI_WORKFLOW_PATH:-/app/secrets/comfyui-workflow.json}
+      ComfyUi__PromptNodeId: ${COMFYUI_PROMPT_NODE_ID:-}
+      ComfyUi__OutputDirectory: ${COMFYUI_OUTPUT_DIR:-/app/assets/blog-images}
+      # Feed-ranking LLM scoring gate (section-12). Irreversible token spend when true.
+      IdeaScoring__ScoringEnabled: ${IDEA_SCORING_ENABLED:-false}
+    volumes:
+      - ./secrets:/app/secrets:ro
+      - ${BLOG_REPO_PATH:-./blog-repo}:/app/blog-repo:rw

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
 services:
   db:
-    image: postgres:17-alpine
+    # pgvector/pgvector:pg17 (Debian/glibc) — feed-ranking needs the `vector` extension,
+    # which vanilla postgres:17-alpine cannot provide. Migrated via logical pg_dump → fresh
+    # volume restore (no in-place musl→glibc collation drift). See planning/feed-ranking/section-12.
+    image: pgvector/pgvector:pg17
     container_name: pba-db
     environment:
       POSTGRES_USER: ${POSTGRES_USER}

--- a/planning/feed-ranking/RESUME.md
+++ b/planning/feed-ranking/RESUME.md
@@ -10,6 +10,19 @@ migrations on both hosts → verify seed → backfill ~3,800 embeddings → **fl
 true + restart (IRREVERSIBLE token spend — needs explicit go-ahead)** → verify → promote to Furious →
 R-L6 grep the two deployed appsettings. Nothing else to `/deep-implement`.
 
+### ⏸ ROLLOUT PAUSED (2026-06-16) — two blockers found at step 0 (read-only SSH recon, NO changes made)
+- **Mac Mini = `192.168.50.189`** (key SSH works); the `.103` in older memory is stale/unreachable. Repo
+  `/Users/matthewkruczek/personal-brand-assistant` on `v2-rebuild` @ `5f50c71c` (behind origin). Docker over
+  SSH needs a login shell (`ssh … 'bash -lc "docker ps"'`). pba-db/api/web all running.
+- **BLOCKER 1 — no pgvector in prod:** `db` image = `postgres:17-alpine` (vanilla). `CREATE EXTENSION vector`
+  (section-01 migration) will FAIL. Must back up (`pg_dump`) then swap to a pgvector image on the same
+  `pgdata` volume (`pgvector/pgvector:pg17` matches PG17 but is glibc vs current musl → possible collation
+  REINDEX; an Alpine pgvector image or installing the extension is lower-risk). User-gated DB change.
+- **BLOCKER 2 — migration apply mechanism unknown:** NO `Database.Migrate()` anywhere in `src/` → not
+  auto-applied on API startup. Check the api Dockerfile/entrypoint on the host (or it's a manual
+  `dotnet ef database update`). Resolve before deploying.
+- Full detail + resume steps in the auto-memory `project_feed_ranking_rollout.md`.
+
 ### Section commits (this rebuild)
 01 95589d7 · 02 196eb9b · 03 eedf22b · 04 afdfdad · 05-07 27f241d (build-coupled) · 08 bba00c6 ·
 09 30c98e0 · 10 e8a3908 · 11 24583f0 · 12 9cfd92e · usage 669d5f8

--- a/scripts/seed-microsoft-sources.sql
+++ b/scripts/seed-microsoft-sources.sql
@@ -1,28 +1,25 @@
--- Ensure the Microsoft-owned RSS sources exist and are flagged for the "Microsoft" daily brief.
+-- Ensure Microsoft-owned RSS sources are flagged for the "Microsoft" daily brief.
 --
 -- WHY THIS EXISTS: IdeaSource seeding only runs via POST /api/idea-sources/seed (Development only), so on
 -- the production Mac Mini host these rows are managed by hand. The Microsoft brief filters on the
--- IsMicrosoftSource flag (NOT on Category, which stays topical: Azure/Cloud, .NET/C#, etc.).
+-- IsMicrosoftSource flag (NOT on Category, which stays topical: Azure/Cloud, .NET/C#, Security, etc.).
 --
--- Run AFTER the AddIsMicrosoftSource migration (the flag column must exist). Idempotent: sets the flag on
--- existing sources (matched case-insensitively on FeedUrl) and inserts any that are missing.
+-- The flag is set by DOMAIN, not a hardcoded feed list: any source on a Microsoft-owned host
+-- (*.microsoft.com or github.blog) is Microsoft. This catches the full set (Azure, .NET, M365, Security,
+-- PowerShell, TypeScript, Semantic Kernel, DevBlogs, Research, GitHub blog, ...) including feeds imported
+-- outside the seed service. The ^-anchor prevents matching lookalikes like notmicrosoft.com, and github.blog
+-- (Microsoft's blog) is included while github.com/<third-party> repos are not.
 --
--- Apply on the Mac Mini, e.g.:
+-- Run AFTER the AddIsMicrosoftSource migration. Idempotent. Apply on the Mac Mini, e.g.:
 --   docker exec -i pba-db psql -U pba -d personal_brand_assistant -v ON_ERROR_STOP=1 < scripts/seed-microsoft-sources.sql
 
--- 1) Flag any already-present Microsoft sources (they may carry topical categories like Azure/Cloud).
+-- 1) Flag every source on a Microsoft-owned domain.
 UPDATE "IdeaSources" SET "IsMicrosoftSource" = TRUE
-WHERE lower("FeedUrl") IN (
-    'https://blogs.microsoft.com/feed/',
-    'https://azure.microsoft.com/en-us/blog/feed/',
-    'https://devblogs.microsoft.com/feed/',
-    'https://devblogs.microsoft.com/dotnet/feed/',
-    'https://devblogs.microsoft.com/visualstudio/feed/',
-    'https://www.microsoft.com/en-us/research/feed/',
-    'https://github.blog/feed/'
-);
+WHERE "FeedUrl" ~* '^https?://([a-z0-9-]+\.)*microsoft\.com/'
+   OR "FeedUrl" ~* '^https?://([a-z0-9-]+\.)*github\.blog/';
 
--- 2) Insert any that are missing, flagged and with a sensible topical category.
+-- 2) Insert the canonical Microsoft feeds if missing (for hosts without the News Hub source set),
+--    flagged and with a sensible topical category.
 INSERT INTO "IdeaSources"
     ("Id", "Name", "Type", "FeedUrl", "ApiUrl", "Category", "IsMicrosoftSource",
      "PollIntervalMinutes", "IsEnabled", "LastPolledAt", "LastSuccessAt", "LastError", "ConsecutiveFailures")

--- a/scripts/seed-microsoft-sources.sql
+++ b/scripts/seed-microsoft-sources.sql
@@ -1,32 +1,43 @@
--- One-off seed: Microsoft-owned RSS sources for the "Microsoft" daily brief.
+-- Ensure the Microsoft-owned RSS sources exist and are flagged for the "Microsoft" daily brief.
 --
--- WHY THIS EXISTS: IdeaSource seeding only runs via POST /api/idea-sources/seed, which is registered
--- in Development only. On the production Mac Mini host there is no seed endpoint and seeding does not
--- run at startup, so these rows must be inserted directly once. Mirrors the Microsoft entries in
--- IdeaSourceSeedService.cs exactly (Type=RSS=0, Category='Microsoft', poll 60m, enabled).
+-- WHY THIS EXISTS: IdeaSource seeding only runs via POST /api/idea-sources/seed (Development only), so on
+-- the production Mac Mini host these rows are managed by hand. The Microsoft brief filters on the
+-- IsMicrosoftSource flag (NOT on Category, which stays topical: Azure/Cloud, .NET/C#, etc.).
 --
--- Idempotent: re-running inserts nothing already present (matched case-insensitively on FeedUrl, the
--- same key IdeaSourceSeedService dedups on). Safe to run before or after a code deploy.
+-- Run AFTER the AddIsMicrosoftSource migration (the flag column must exist). Idempotent: sets the flag on
+-- existing sources (matched case-insensitively on FeedUrl) and inserts any that are missing.
 --
 -- Apply on the Mac Mini, e.g.:
---   docker compose exec -T db psql -U <user> -d <database> -f - < scripts/seed-microsoft-sources.sql
--- (or pipe the file into psql however the other migrations are applied on that host).
+--   docker exec -i pba-db psql -U pba -d personal_brand_assistant -v ON_ERROR_STOP=1 < scripts/seed-microsoft-sources.sql
 
+-- 1) Flag any already-present Microsoft sources (they may carry topical categories like Azure/Cloud).
+UPDATE "IdeaSources" SET "IsMicrosoftSource" = TRUE
+WHERE lower("FeedUrl") IN (
+    'https://blogs.microsoft.com/feed/',
+    'https://azure.microsoft.com/en-us/blog/feed/',
+    'https://devblogs.microsoft.com/feed/',
+    'https://devblogs.microsoft.com/dotnet/feed/',
+    'https://devblogs.microsoft.com/visualstudio/feed/',
+    'https://www.microsoft.com/en-us/research/feed/',
+    'https://github.blog/feed/'
+);
+
+-- 2) Insert any that are missing, flagged and with a sensible topical category.
 INSERT INTO "IdeaSources"
-    ("Id", "Name", "Type", "FeedUrl", "ApiUrl", "Category",
+    ("Id", "Name", "Type", "FeedUrl", "ApiUrl", "Category", "IsMicrosoftSource",
      "PollIntervalMinutes", "IsEnabled", "LastPolledAt", "LastSuccessAt", "LastError", "ConsecutiveFailures")
 SELECT
-    gen_random_uuid(), v.name, 0, v.feedurl, NULL, 'Microsoft',
+    gen_random_uuid(), v.name, 0, v.feedurl, NULL, v.category, TRUE,
     60, TRUE, NULL, NULL, NULL, 0
 FROM (VALUES
-    ('Microsoft Blog',      'https://blogs.microsoft.com/feed/'),
-    ('Azure Blog',          'https://azure.microsoft.com/en-us/blog/feed/'),
-    ('Microsoft Dev Blogs', 'https://devblogs.microsoft.com/feed/'),
-    ('.NET Blog',           'https://devblogs.microsoft.com/dotnet/feed/'),
-    ('Visual Studio Blog',  'https://devblogs.microsoft.com/visualstudio/feed/'),
-    ('Microsoft Research',  'https://www.microsoft.com/en-us/research/feed/'),
-    ('GitHub Blog',         'https://github.blog/feed/')
-) AS v(name, feedurl)
+    ('Microsoft Blog',     'https://blogs.microsoft.com/feed/',                'Microsoft'),
+    ('Azure Blog',         'https://azure.microsoft.com/en-us/blog/feed/',     'Azure/Cloud'),
+    ('Microsoft DevBlogs', 'https://devblogs.microsoft.com/feed/',             'Microsoft'),
+    ('.NET Blog',          'https://devblogs.microsoft.com/dotnet/feed/',      '.NET/C#'),
+    ('Visual Studio Blog', 'https://devblogs.microsoft.com/visualstudio/feed/','.NET/C#'),
+    ('Microsoft Research', 'https://www.microsoft.com/en-us/research/feed/',   'Microsoft'),
+    ('GitHub Blog',        'https://github.blog/feed/',                        'DevOps')
+) AS v(name, feedurl, category)
 WHERE NOT EXISTS (
     SELECT 1 FROM "IdeaSources" s WHERE lower(s."FeedUrl") = lower(v.feedurl)
 );

--- a/scripts/seed-microsoft-sources.sql
+++ b/scripts/seed-microsoft-sources.sql
@@ -1,0 +1,32 @@
+-- One-off seed: Microsoft-owned RSS sources for the "Microsoft" daily brief.
+--
+-- WHY THIS EXISTS: IdeaSource seeding only runs via POST /api/idea-sources/seed, which is registered
+-- in Development only. On the production Mac Mini host there is no seed endpoint and seeding does not
+-- run at startup, so these rows must be inserted directly once. Mirrors the Microsoft entries in
+-- IdeaSourceSeedService.cs exactly (Type=RSS=0, Category='Microsoft', poll 60m, enabled).
+--
+-- Idempotent: re-running inserts nothing already present (matched case-insensitively on FeedUrl, the
+-- same key IdeaSourceSeedService dedups on). Safe to run before or after a code deploy.
+--
+-- Apply on the Mac Mini, e.g.:
+--   docker compose exec -T db psql -U <user> -d <database> -f - < scripts/seed-microsoft-sources.sql
+-- (or pipe the file into psql however the other migrations are applied on that host).
+
+INSERT INTO "IdeaSources"
+    ("Id", "Name", "Type", "FeedUrl", "ApiUrl", "Category",
+     "PollIntervalMinutes", "IsEnabled", "LastPolledAt", "LastSuccessAt", "LastError", "ConsecutiveFailures")
+SELECT
+    gen_random_uuid(), v.name, 0, v.feedurl, NULL, 'Microsoft',
+    60, TRUE, NULL, NULL, NULL, 0
+FROM (VALUES
+    ('Microsoft Blog',      'https://blogs.microsoft.com/feed/'),
+    ('Azure Blog',          'https://azure.microsoft.com/en-us/blog/feed/'),
+    ('Microsoft Dev Blogs', 'https://devblogs.microsoft.com/feed/'),
+    ('.NET Blog',           'https://devblogs.microsoft.com/dotnet/feed/'),
+    ('Visual Studio Blog',  'https://devblogs.microsoft.com/visualstudio/feed/'),
+    ('Microsoft Research',  'https://www.microsoft.com/en-us/research/feed/'),
+    ('GitHub Blog',         'https://github.blog/feed/')
+) AS v(name, feedurl)
+WHERE NOT EXISTS (
+    SELECT 1 FROM "IdeaSources" s WHERE lower(s."FeedUrl") = lower(v.feedurl)
+);

--- a/src/PBA.Api/Authentication/ApiKeyEndpointFilter.cs
+++ b/src/PBA.Api/Authentication/ApiKeyEndpointFilter.cs
@@ -1,0 +1,49 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Options;
+
+namespace PBA.Api.Authentication;
+
+/// <summary>
+/// Endpoint filter guarding the /api/external surface. Validates the X-Api-Key header
+/// against the configured ExternalApi:ApiKey using a constant-time comparison.
+/// Fails closed: if no key is configured, every request is rejected rather than allowed.
+/// </summary>
+public sealed class ApiKeyEndpointFilter(
+    IOptionsMonitor<ExternalApiOptions> options,
+    ILogger<ApiKeyEndpointFilter> logger) : IEndpointFilter
+{
+    public const string HeaderName = "X-Api-Key";
+
+    public async ValueTask<object?> InvokeAsync(
+        EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+    {
+        var configuredKey = options.CurrentValue.ApiKey;
+
+        if (string.IsNullOrWhiteSpace(configuredKey))
+        {
+            logger.LogWarning(
+                "External API request to {Path} rejected: ExternalApi:ApiKey is not configured.",
+                context.HttpContext.Request.Path);
+            return Results.Unauthorized();
+        }
+
+        var provided = context.HttpContext.Request.Headers[HeaderName].ToString();
+        if (!IsValidKey(provided, configuredKey))
+            return Results.Unauthorized();
+
+        return await next(context);
+    }
+
+    private static bool IsValidKey(string provided, string configured)
+    {
+        if (string.IsNullOrEmpty(provided))
+            return false;
+
+        // FixedTimeEquals returns false on length mismatch and compares equal-length
+        // inputs in constant time, avoiding a byte-by-byte timing side channel.
+        return CryptographicOperations.FixedTimeEquals(
+            Encoding.UTF8.GetBytes(provided),
+            Encoding.UTF8.GetBytes(configured));
+    }
+}

--- a/src/PBA.Api/Authentication/ExternalApiOptions.cs
+++ b/src/PBA.Api/Authentication/ExternalApiOptions.cs
@@ -1,0 +1,14 @@
+namespace PBA.Api.Authentication;
+
+/// <summary>
+/// Configuration for the external API surface (/api/external) consumed by trusted
+/// server-to-server clients such as project-avatar. Bound from the "ExternalApi"
+/// configuration section. The key is supplied via User Secrets (dev) or an
+/// ExternalApi__ApiKey environment variable (prod) — never committed.
+/// </summary>
+public sealed class ExternalApiOptions
+{
+    public const string SectionName = "ExternalApi";
+
+    public string ApiKey { get; init; } = string.Empty;
+}

--- a/src/PBA.Api/Endpoints/DigestEndpoints.cs
+++ b/src/PBA.Api/Endpoints/DigestEndpoints.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using PBA.Api.Extensions;
 using PBA.Application.Features.Digests.Queries;
+using PBA.Domain.Enums;
 
 namespace PBA.Api.Endpoints;
 
@@ -10,13 +11,23 @@ public static class DigestEndpoints
     {
         var group = app.MapGroup("/api/digests").WithTags("Digests");
 
+        // History spine — Main briefs only.
         group.MapGet("/", async (ISender sender, CancellationToken ct) =>
             (await sender.Send(new ListDigests.Query(), ct)).ToApiResult());
 
-        group.MapGet("/latest", async (ISender sender, CancellationToken ct) =>
-            (await sender.Send(new GetLatestDigest.Query(), ct)).ToApiResult());
+        group.MapGet("/latest", async (string? kind, ISender sender, CancellationToken ct) =>
+            (await sender.Send(new GetLatestDigest.Query(ParseKind(kind)), ct)).ToApiResult());
+
+        group.MapGet("/by-date/{date:datetime}", async (
+            DateTime date, string? kind, ISender sender, CancellationToken ct) =>
+            (await sender.Send(new GetDigestByDate.Query(DateOnly.FromDateTime(date), ParseKind(kind)), ct)).ToApiResult());
 
         group.MapGet("/{id:guid}", async (Guid id, ISender sender, CancellationToken ct) =>
             (await sender.Send(new GetDigest.Query(id), ct)).ToApiResult());
     }
+
+    private static DigestKind ParseKind(string? kind) =>
+        string.Equals(kind, "microsoft", StringComparison.OrdinalIgnoreCase)
+            ? DigestKind.Microsoft
+            : DigestKind.Main;
 }

--- a/src/PBA.Api/Endpoints/ExternalEndpoints.cs
+++ b/src/PBA.Api/Endpoints/ExternalEndpoints.cs
@@ -1,0 +1,140 @@
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using PBA.Api.Authentication;
+using PBA.Api.Extensions;
+using PBA.Application.Features.Analytics.Queries;
+using PBA.Application.Features.Content.Queries;
+using PBA.Application.Features.Digests.Queries;
+using PBA.Application.Features.Feed.Queries;
+using PBA.Application.Features.Ideas.Commands;
+using PBA.Application.Features.Ideas.Queries;
+using PBA.Domain.Enums;
+
+namespace PBA.Api.Endpoints;
+
+/// <summary>
+/// Read-mostly API surface for trusted server-to-server consumers (project-avatar).
+/// Every route is guarded by <see cref="ApiKeyEndpointFilter"/>. Reads reuse the same
+/// MediatR queries as the internal UI endpoints; the single write injects an idea into
+/// the Idea Bank. Publishing and feed-mutation actions are intentionally not exposed here.
+/// </summary>
+public static class ExternalEndpoints
+{
+    public static void MapExternalEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/external")
+            .WithTags("External")
+            .AddEndpointFilter<ApiKeyEndpointFilter>();
+
+        // --- Reads ---
+
+        group.MapGet("/feed", async (
+            [AsParameters] ListFeedQueryParams p, ISender sender, CancellationToken ct) =>
+        {
+            var query = new ListFeedItems.Query
+            {
+                Page = p.Page ?? 1,
+                PageSize = Math.Clamp(p.PageSize ?? 20, 1, 100),
+                Type = p.Type,
+                Priority = p.Priority,
+                IsRead = p.IsRead,
+                IncludeExpired = p.IncludeExpired ?? false,
+                SortBy = p.SortBy ?? "CreatedAt",
+                SortDirection = p.SortDirection ?? "desc"
+            };
+            return (await sender.Send(query, ct)).ToApiResult();
+        });
+
+        group.MapGet("/feed/trending", async (ISender sender, CancellationToken ct) =>
+            (await sender.Send(new GetTrendingTopics.Query(), ct)).ToApiResult());
+
+        group.MapGet("/ideas", async (
+            [AsParameters] ListIdeasQueryParams p, ISender sender, CancellationToken ct) =>
+        {
+            var query = new ListIdeas.Query
+            {
+                Page = p.Page ?? 1,
+                PageSize = Math.Clamp(p.PageSize ?? 20, 1, 100),
+                Status = p.Status,
+                IdeaSourceId = p.IdeaSourceId,
+                Category = p.Category,
+                Tags = p.Tags,
+                DateFrom = p.DateFrom,
+                DateTo = p.DateTo,
+                SearchText = p.SearchText,
+                SortBy = p.SortBy ?? "rank",
+                SortDirection = p.SortDirection ?? "desc",
+                MinScore = p.MinScore,
+                IncludeDuplicates = p.IncludeDuplicates ?? false
+            };
+            return (await sender.Send(query, ct)).ToApiResult();
+        });
+
+        group.MapGet("/digests/latest", async (string? kind, ISender sender, CancellationToken ct) =>
+            (await sender.Send(new GetLatestDigest.Query(ParseKind(kind)), ct)).ToApiResult());
+
+        group.MapGet("/content", async (
+            [AsParameters] ListContentQueryParams p, ISender sender, CancellationToken ct) =>
+        {
+            var query = new ListContent.Query
+            {
+                Page = p.Page ?? 1,
+                PageSize = Math.Clamp(p.PageSize ?? 20, 1, 100),
+                Status = p.Status,
+                Platform = p.Platform,
+                ContentType = p.ContentType,
+                DateFrom = p.DateFrom,
+                DateTo = p.DateTo,
+                Search = p.Search
+            };
+            return (await sender.Send(query, ct)).ToApiResult();
+        });
+
+        group.MapGet("/analytics/website", async (string? period, ISender sender, CancellationToken ct) =>
+        {
+            var (from, to) = ResolveRange(period);
+            return (await sender.Send(new GetWebsiteAnalytics.Query(from, to), ct)).ToApiResult();
+        });
+
+        // --- Bounded write ---
+
+        group.MapPost("/ideas", async (CreateExternalIdeaRequest body, ISender sender, CancellationToken ct) =>
+        {
+            var command = new CreateIdea.Command
+            {
+                Title = body.Title,
+                Description = body.Description,
+                Url = body.Url,
+                Category = body.Category,
+                Tags = body.Tags ?? []
+            };
+            var result = await sender.Send(command, ct);
+            return result.IsSuccess
+                ? Results.Created($"/api/external/ideas/{result.Value}", new { id = result.Value })
+                : result.ToApiResult();
+        });
+    }
+
+    private static DigestKind ParseKind(string? kind) =>
+        string.Equals(kind, "microsoft", StringComparison.OrdinalIgnoreCase)
+            ? DigestKind.Microsoft
+            : DigestKind.Main;
+
+    // Bot-friendly subset of the analytics range options (period only; defaults to 30 days).
+    private static (DateTimeOffset From, DateTimeOffset To) ResolveRange(string? period)
+    {
+        var today = DateTimeOffset.UtcNow.Date;
+        var days = period switch { "7d" => 7, "90d" => 90, _ => 30 };
+        return (new DateTimeOffset(today.AddDays(-(days - 1)), TimeSpan.Zero),
+                new DateTimeOffset(today, TimeSpan.Zero));
+    }
+}
+
+public record CreateExternalIdeaRequest
+{
+    public string Title { get; init; } = string.Empty;
+    public string? Description { get; init; }
+    public string? Url { get; init; }
+    public string? Category { get; init; }
+    public IReadOnlyList<string>? Tags { get; init; }
+}

--- a/src/PBA.Api/Program.cs
+++ b/src/PBA.Api/Program.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Serialization;
 using Hangfire;
 using Hangfire.PostgreSql;
+using PBA.Api.Authentication;
 using PBA.Api.Endpoints;
 using PBA.Api.Hubs;
 using PBA.Api.Services;
@@ -12,6 +13,9 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddApplicationDependencies();
 builder.Services.AddInfrastructureDependencies(builder.Configuration);
+
+builder.Services.Configure<ExternalApiOptions>(
+    builder.Configuration.GetSection(ExternalApiOptions.SectionName));
 
 builder.Services.AddCors(options =>
 {
@@ -68,6 +72,7 @@ app.MapFeedEndpoints();
 app.MapAnalyticsEndpoints();
 app.MapDigestEndpoints();
 app.MapBrandRankingProfileEndpoints();
+app.MapExternalEndpoints();
 
 app.MapHub<ContentHub>("/hubs/content");
 app.MapHub<FeedHub>("/hubs/feed");

--- a/src/PBA.Api/appsettings.json
+++ b/src/PBA.Api/appsettings.json
@@ -96,5 +96,6 @@
     }
   },
   "HackerNews": { "MinScore": 100, "FetchTopStories": 30, "TopComments": 5 },
-  "GitHubScraper": { "Token": "", "MaxEventsPerSource": 30 }
+  "GitHubScraper": { "Token": "", "MaxEventsPerSource": 30 },
+  "ExternalApi": { "ApiKey": "" }
 }

--- a/src/PBA.Application/Common/Interfaces/IDigestWriter.cs
+++ b/src/PBA.Application/Common/Interfaces/IDigestWriter.cs
@@ -1,3 +1,5 @@
+using PBA.Domain.Enums;
+
 namespace PBA.Application.Common.Interfaces;
 
 public sealed record DigestInput(int Index, string Title, string Summary, int Score, string? Url);
@@ -9,8 +11,10 @@ public sealed record DigestCopy(string Title, string Intro, IReadOnlyList<Digest
 public interface IDigestWriter
 {
     /// <summary>
-    /// Writes a brand-voice daily brief (no em-dashes) over the top items.
-    /// Returns null if the model output cannot be parsed.
+    /// Writes a brand-voice brief (no em-dashes) over the top items. <paramref name="kind"/> selects the
+    /// framing: the general brief or the Microsoft-focused brief. Returns null if the model output cannot
+    /// be parsed.
     /// </summary>
-    Task<DigestCopy?> WriteAsync(IReadOnlyList<DigestInput> items, CancellationToken ct = default);
+    Task<DigestCopy?> WriteAsync(
+        IReadOnlyList<DigestInput> items, DigestKind kind = DigestKind.Main, CancellationToken ct = default);
 }

--- a/src/PBA.Application/Features/Digests/Queries/GetDigestByDate.cs
+++ b/src/PBA.Application/Features/Digests/Queries/GetDigestByDate.cs
@@ -1,0 +1,35 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using PBA.Application.Common.Interfaces;
+using PBA.Application.Features.Digests.Dtos;
+using PBA.Domain.Common;
+using PBA.Domain.Enums;
+
+namespace PBA.Application.Features.Digests.Queries;
+
+/// <summary>
+/// Fetches a specific date's digest for a given kind. Used to load the Microsoft brief that sits beside
+/// the selected Main brief (which the UI selects by date from the history spine).
+/// </summary>
+public static class GetDigestByDate
+{
+    public record Query(DateOnly Date, DigestKind Kind = DigestKind.Main) : IRequest<Result<DigestDto>>;
+
+    public sealed class Handler(IAppDbContext db) : IRequestHandler<Query, Result<DigestDto>>
+    {
+        public async Task<Result<DigestDto>> Handle(Query request, CancellationToken ct)
+        {
+            var digest = await db.Digests
+                .AsNoTracking()
+                .Include(d => d.Items)
+                    .ThenInclude(i => i.Idea)
+                .Where(d => d.Date == request.Date && d.Kind == request.Kind)
+                .FirstOrDefaultAsync(ct);
+
+            if (digest is null)
+                return Result<DigestDto>.NotFound("No digest for that date.");
+
+            return GetLatestDigest.Handler.ToDto(digest);
+        }
+    }
+}

--- a/src/PBA.Application/Features/Digests/Queries/GetLatestDigest.cs
+++ b/src/PBA.Application/Features/Digests/Queries/GetLatestDigest.cs
@@ -4,12 +4,13 @@ using Microsoft.EntityFrameworkCore;
 using PBA.Application.Common.Interfaces;
 using PBA.Application.Features.Digests.Dtos;
 using PBA.Domain.Common;
+using PBA.Domain.Enums;
 
 namespace PBA.Application.Features.Digests.Queries;
 
 public static class GetLatestDigest
 {
-    public record Query : IRequest<Result<DigestDto>>;
+    public record Query(DigestKind Kind = DigestKind.Main) : IRequest<Result<DigestDto>>;
 
     public sealed class Handler(IAppDbContext db) : IRequestHandler<Query, Result<DigestDto>>
     {
@@ -19,6 +20,7 @@ public static class GetLatestDigest
                 .AsNoTracking()
                 .Include(d => d.Items)
                     .ThenInclude(i => i.Idea)
+                .Where(d => d.Kind == request.Kind)
                 .OrderByDescending(d => d.Date)
                 .FirstOrDefaultAsync(ct);
 

--- a/src/PBA.Application/Features/Digests/Queries/ListDigests.cs
+++ b/src/PBA.Application/Features/Digests/Queries/ListDigests.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using PBA.Application.Common.Interfaces;
 using PBA.Application.Features.Digests.Dtos;
 using PBA.Domain.Common;
+using PBA.Domain.Enums;
 
 namespace PBA.Application.Features.Digests.Queries;
 
@@ -14,8 +15,10 @@ public static class ListDigests
     {
         public async Task<Result<IReadOnlyList<DigestSummaryDto>>> Handle(Query request, CancellationToken ct)
         {
+            // The history spine is the Main brief; the Microsoft brief is loaded by date alongside it.
             var items = await db.Digests
                 .AsNoTracking()
+                .Where(d => d.Kind == DigestKind.Main)
                 .OrderByDescending(d => d.Date)
                 .Select(d => new DigestSummaryDto
                 {

--- a/src/PBA.Domain/Entities/Digest.cs
+++ b/src/PBA.Domain/Entities/Digest.cs
@@ -1,9 +1,12 @@
 namespace PBA.Domain.Entities;
 
+using PBA.Domain.Enums;
+
 public class Digest
 {
     public Guid Id { get; init; } = Guid.NewGuid();
     public DateOnly Date { get; set; }
+    public DigestKind Kind { get; set; } = DigestKind.Main;
     public required string Title { get; set; }
     public required string Intro { get; set; }
     public int ItemCount { get; set; }

--- a/src/PBA.Domain/Entities/IdeaSource.cs
+++ b/src/PBA.Domain/Entities/IdeaSource.cs
@@ -10,6 +10,11 @@ public class IdeaSource
     public string? FeedUrl { get; set; }
     public string? ApiUrl { get; set; }
     public string Category { get; set; } = string.Empty;
+
+    /// <summary>True if this source is Microsoft-owned (Azure, .NET, GitHub, MS blogs/research). Drives the
+    /// Microsoft daily brief independently of <see cref="Category"/>, which stays topical (Azure/Cloud, .NET/C#).</summary>
+    public bool IsMicrosoftSource { get; set; }
+
     public int PollIntervalMinutes { get; set; } = 30;
     public bool IsEnabled { get; set; } = true;
     public DateTimeOffset? LastPolledAt { get; set; }

--- a/src/PBA.Domain/Enums/DigestKind.cs
+++ b/src/PBA.Domain/Enums/DigestKind.cs
@@ -1,0 +1,14 @@
+namespace PBA.Domain.Enums;
+
+/// <summary>
+/// Which brief a <see cref="Entities.Digest"/> belongs to. Stored as int (Main=0) so existing rows
+/// remain valid without a data backfill. One digest per (Date, Kind).
+/// </summary>
+public enum DigestKind
+{
+    /// <summary>The general brand-anchored brief over all sources.</summary>
+    Main = 0,
+
+    /// <summary>Pure-Microsoft brief: only items from Microsoft-owned sources.</summary>
+    Microsoft = 1
+}

--- a/src/PBA.Infrastructure/Configuration/EmbeddingOptions.cs
+++ b/src/PBA.Infrastructure/Configuration/EmbeddingOptions.cs
@@ -7,4 +7,10 @@ public sealed class EmbeddingOptions
     public string Model { get; init; } = "openai/text-embedding-3-small";
     public int Dimensions { get; init; } = 1536;
     public int BatchSize { get; init; } = 128;
+
+    // Per-input character cap. text-embedding-3-small accepts 8191 tokens per input; an over-long idea
+    // (e.g. a full article body) makes the provider return 0 vectors and fails the WHOLE batch (count
+    // mismatch), leaving every co-batched idea unembedded. 20k chars (~5-8k tokens) stays under the limit
+    // while preserving enough text for brand-fit — embeddings only need the topical gist.
+    public int MaxInputChars { get; init; } = 20000;
 }

--- a/src/PBA.Infrastructure/Data/Configurations/DigestConfiguration.cs
+++ b/src/PBA.Infrastructure/Data/Configurations/DigestConfiguration.cs
@@ -11,7 +11,8 @@ public class DigestConfiguration : IEntityTypeConfiguration<Digest>
         builder.HasKey(d => d.Id);
         builder.Property(d => d.Title).IsRequired().HasMaxLength(300);
         builder.Property(d => d.Intro).HasColumnType("text").IsRequired();
-        builder.HasIndex(d => d.Date).IsUnique();
+        // One digest per (date, kind): the Main and Microsoft briefs share a date.
+        builder.HasIndex(d => new { d.Date, d.Kind }).IsUnique();
 
         builder.HasMany(d => d.Items)
             .WithOne(i => i.Digest!)

--- a/src/PBA.Infrastructure/Data/Migrations/20260617141029_AddDigestKind.Designer.cs
+++ b/src/PBA.Infrastructure/Data/Migrations/20260617141029_AddDigestKind.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using PBA.Infrastructure.Data;
@@ -12,9 +13,11 @@ using Pgvector;
 namespace PBA.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260617141029_AddDigestKind")]
+    partial class AddDigestKind
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/PBA.Infrastructure/Data/Migrations/20260617141029_AddDigestKind.cs
+++ b/src/PBA.Infrastructure/Data/Migrations/20260617141029_AddDigestKind.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PBA.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDigestKind : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Digests_Date",
+                table: "Digests");
+
+            migrationBuilder.AddColumn<int>(
+                name: "Kind",
+                table: "Digests",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Digests_Date_Kind",
+                table: "Digests",
+                columns: new[] { "Date", "Kind" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Digests_Date_Kind",
+                table: "Digests");
+
+            migrationBuilder.DropColumn(
+                name: "Kind",
+                table: "Digests");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Digests_Date",
+                table: "Digests",
+                column: "Date",
+                unique: true);
+        }
+    }
+}

--- a/src/PBA.Infrastructure/Data/Migrations/20260617144341_AddIsMicrosoftSource.Designer.cs
+++ b/src/PBA.Infrastructure/Data/Migrations/20260617144341_AddIsMicrosoftSource.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using PBA.Infrastructure.Data;
@@ -12,9 +13,11 @@ using Pgvector;
 namespace PBA.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260617144341_AddIsMicrosoftSource")]
+    partial class AddIsMicrosoftSource
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/PBA.Infrastructure/Data/Migrations/20260617144341_AddIsMicrosoftSource.cs
+++ b/src/PBA.Infrastructure/Data/Migrations/20260617144341_AddIsMicrosoftSource.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PBA.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIsMicrosoftSource : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsMicrosoftSource",
+                table: "IdeaSources",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsMicrosoftSource",
+                table: "IdeaSources");
+        }
+    }
+}

--- a/src/PBA.Infrastructure/Seeding/IdeaSourceSeedService.cs
+++ b/src/PBA.Infrastructure/Seeding/IdeaSourceSeedService.cs
@@ -29,6 +29,17 @@ public sealed class IdeaSourceSeedService(IAppDbContext db) : IIdeaSourceSeedSer
         ("TLDR Fintech", "https://tldr.tech/api/rss/fintech", "Fintech"),
         ("TLDR Data", "https://tldr.tech/api/rss/data", "Data"),
         ("TLDR IT", "https://tldr.tech/api/rss/it", "IT"),
+
+        // Microsoft-owned sources — Category "Microsoft" is the marker the Microsoft brief filters on
+        // (DigestService selects ideas whose IdeaSource.Category == "Microsoft"). All verified to return
+        // valid RSS; the feed reader sends a Chrome UA so the Akamai-fronted corporate blogs don't 403.
+        ("Microsoft Blog", "https://blogs.microsoft.com/feed/", "Microsoft"),
+        ("Azure Blog", "https://azure.microsoft.com/en-us/blog/feed/", "Microsoft"),
+        ("Microsoft Dev Blogs", "https://devblogs.microsoft.com/feed/", "Microsoft"),
+        (".NET Blog", "https://devblogs.microsoft.com/dotnet/feed/", "Microsoft"),
+        ("Visual Studio Blog", "https://devblogs.microsoft.com/visualstudio/feed/", "Microsoft"),
+        ("Microsoft Research", "https://www.microsoft.com/en-us/research/feed/", "Microsoft"),
+        ("GitHub Blog", "https://github.blog/feed/", "Microsoft"),
     ];
 
     public async Task<int> SeedAsync(CancellationToken cancellationToken = default)

--- a/src/PBA.Infrastructure/Seeding/IdeaSourceSeedService.cs
+++ b/src/PBA.Infrastructure/Seeding/IdeaSourceSeedService.cs
@@ -29,17 +29,20 @@ public sealed class IdeaSourceSeedService(IAppDbContext db) : IIdeaSourceSeedSer
         ("TLDR Fintech", "https://tldr.tech/api/rss/fintech", "Fintech"),
         ("TLDR Data", "https://tldr.tech/api/rss/data", "Data"),
         ("TLDR IT", "https://tldr.tech/api/rss/it", "IT"),
+    ];
 
-        // Microsoft-owned sources — Category "Microsoft" is the marker the Microsoft brief filters on
-        // (DigestService selects ideas whose IdeaSource.Category == "Microsoft"). All verified to return
-        // valid RSS; the feed reader sends a Chrome UA so the Akamai-fronted corporate blogs don't 403.
+    // Microsoft-owned sources. Category stays topical; IsMicrosoftSource (set below) is what the Microsoft
+    // brief filters on. All verified to return valid RSS; the feed reader sends a Chrome UA so the
+    // Akamai-fronted corporate blogs don't 403.
+    private static readonly (string Name, string FeedUrl, string Category)[] MicrosoftFeeds =
+    [
         ("Microsoft Blog", "https://blogs.microsoft.com/feed/", "Microsoft"),
-        ("Azure Blog", "https://azure.microsoft.com/en-us/blog/feed/", "Microsoft"),
-        ("Microsoft Dev Blogs", "https://devblogs.microsoft.com/feed/", "Microsoft"),
-        (".NET Blog", "https://devblogs.microsoft.com/dotnet/feed/", "Microsoft"),
-        ("Visual Studio Blog", "https://devblogs.microsoft.com/visualstudio/feed/", "Microsoft"),
+        ("Azure Blog", "https://azure.microsoft.com/en-us/blog/feed/", "Azure/Cloud"),
+        ("Microsoft DevBlogs", "https://devblogs.microsoft.com/feed/", "Microsoft"),
+        (".NET Blog", "https://devblogs.microsoft.com/dotnet/feed/", ".NET/C#"),
+        ("Visual Studio Blog", "https://devblogs.microsoft.com/visualstudio/feed/", ".NET/C#"),
         ("Microsoft Research", "https://www.microsoft.com/en-us/research/feed/", "Microsoft"),
-        ("GitHub Blog", "https://github.blog/feed/", "Microsoft"),
+        ("GitHub Blog", "https://github.blog/feed/", "DevOps"),
     ];
 
     public async Task<int> SeedAsync(CancellationToken cancellationToken = default)
@@ -52,22 +55,29 @@ public sealed class IdeaSourceSeedService(IAppDbContext db) : IIdeaSourceSeedSer
         var existingSet = new HashSet<string>(existingUrls, StringComparer.OrdinalIgnoreCase);
         var added = 0;
 
-        foreach (var (name, feedUrl, category) in Feeds)
+        void AddMissing((string Name, string FeedUrl, string Category)[] feeds, bool isMicrosoft)
         {
-            if (existingSet.Contains(feedUrl))
-                continue;
-
-            db.IdeaSources.Add(new IdeaSource
+            foreach (var (name, feedUrl, category) in feeds)
             {
-                Name = name,
-                Type = IdeaSourceType.RSS,
-                FeedUrl = feedUrl,
-                Category = category,
-                PollIntervalMinutes = 60,
-                IsEnabled = true,
-            });
-            added++;
+                if (existingSet.Contains(feedUrl))
+                    continue;
+
+                db.IdeaSources.Add(new IdeaSource
+                {
+                    Name = name,
+                    Type = IdeaSourceType.RSS,
+                    FeedUrl = feedUrl,
+                    Category = category,
+                    IsMicrosoftSource = isMicrosoft,
+                    PollIntervalMinutes = 60,
+                    IsEnabled = true,
+                });
+                added++;
+            }
         }
+
+        AddMissing(Feeds, isMicrosoft: false);
+        AddMissing(MicrosoftFeeds, isMicrosoft: true);
 
         if (added > 0)
             await db.SaveChangesAsync(cancellationToken);

--- a/src/PBA.Infrastructure/Services/OpenRouterClient.cs
+++ b/src/PBA.Infrastructure/Services/OpenRouterClient.cs
@@ -94,7 +94,12 @@ public sealed class OpenRouterClient(
     {
         // Drop empty/whitespace inputs — a meaningless vector would corrupt dedup/pre-filter (R-H2).
         // (API-key validation happens in PostJsonAsync, so an all-empty call returns [] without it.)
-        var sanitized = inputs.Where(i => !string.IsNullOrWhiteSpace(i)).ToList();
+        // Cap each input to MaxInputChars: one over-long input exceeds the model's per-input token limit
+        // and makes the provider return 0 vectors for the whole batch, leaving every co-batched idea null.
+        var sanitized = inputs
+            .Where(i => !string.IsNullOrWhiteSpace(i))
+            .Select(TruncateInput)
+            .ToList();
         if (sanitized.Count == 0)
             return [];
 
@@ -107,6 +112,15 @@ public sealed class OpenRouterClient(
         }
 
         return results;
+    }
+
+    private string TruncateInput(string s)
+    {
+        var max = _embeddingOptions.MaxInputChars;
+        if (max <= 0 || s.Length <= max) return s;
+        // Don't cut through a surrogate pair — a lone surrogate is invalid UTF-16 and breaks JSON encoding.
+        var end = char.IsHighSurrogate(s[max - 1]) ? max - 1 : max;
+        return s[..end];
     }
 
     private async Task<float[][]> EmbedBatchAsync(string[] batch, string model, CancellationToken ct)

--- a/src/PBA.Infrastructure/Services/Radar/DigestService.cs
+++ b/src/PBA.Infrastructure/Services/Radar/DigestService.cs
@@ -46,15 +46,30 @@ public sealed class DigestService(
     {
         using var scope = scopeFactory.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-
-        // Guard: one digest per calendar day (UTC)
         var date = DateOnly.FromDateTime(now.UtcDateTime);
-        if (await db.Digests.AnyAsync(d => d.Date == date, ct))
+
+        // Generate both briefs for the day. Microsoft only delivers in-app (no email/Discord push) and
+        // is skipped when no Microsoft-source items exist yet.
+        foreach (var kind in new[] { DigestKind.Main, DigestKind.Microsoft })
+            await GenerateForKindAsync(scope, db, date, now, kind, ct);
+    }
+
+    private async Task GenerateForKindAsync(
+        IServiceScope scope, ApplicationDbContext db, DateOnly date, DateTimeOffset now, DigestKind kind, CancellationToken ct)
+    {
+        // Guard: one digest per (calendar day UTC, kind)
+        if (await db.Digests.AnyAsync(d => d.Date == date && d.Kind == kind, ct))
             return;
 
         var since = now.AddHours(-_options.LookbackHours);
-        var top = await db.Ideas
-            .Where(i => i.ScoredAt != null && i.Score != null && i.DuplicateOfId == null && i.DetectedAt >= since)
+        var query = db.Ideas
+            .Where(i => i.ScoredAt != null && i.Score != null && i.DuplicateOfId == null && i.DetectedAt >= since);
+
+        // "Pure Microsoft" = items whose source is tagged Microsoft (set in IdeaSourceSeedService).
+        if (kind == DigestKind.Microsoft)
+            query = query.Where(i => i.IdeaSource != null && i.IdeaSource.Category == "Microsoft");
+
+        var top = await query
             .OrderByDescending(i => i.Score)
             .Take(_options.TopN)
             .ToListAsync(ct);
@@ -68,12 +83,13 @@ public sealed class DigestService(
             .Select((idea, idx) => new DigestInput(idx, idea.Title, idea.Summary ?? string.Empty, idea.Score ?? 0, idea.Url))
             .ToList();
 
-        var copy = await writer.WriteAsync(inputs, ct);
+        var copy = await writer.WriteAsync(inputs, kind, ct);
         if (copy is null) return;
 
         var digest = new Digest
         {
             Date = date,
+            Kind = kind,
             Title = copy.Title,
             Intro = copy.Intro,
             ItemCount = top.Count,
@@ -95,18 +111,25 @@ public sealed class DigestService(
 
         db.Digests.Add(digest);
 
-        db.FeedItems.Add(new FeedItem
+        // In-app feed notification + external delivery are for the Main brief only; the Microsoft brief
+        // is surfaced beside it on the Daily Brief page, so a second ping would just be noise.
+        if (kind == DigestKind.Main)
         {
-            Type = FeedItemType.SystemNotification,
-            Title = copy.Title,
-            Summary = copy.Intro.Length > 280 ? copy.Intro[..280] : copy.Intro,
-            Data = JsonSerializer.Serialize(new { digestId = digest.Id }),
-            Priority = FeedItemPriority.Normal,
-            CreatedAt = now
-        });
+            db.FeedItems.Add(new FeedItem
+            {
+                Type = FeedItemType.SystemNotification,
+                Title = copy.Title,
+                Summary = copy.Intro.Length > 280 ? copy.Intro[..280] : copy.Intro,
+                Data = JsonSerializer.Serialize(new { digestId = digest.Id }),
+                Priority = FeedItemPriority.Normal,
+                CreatedAt = now
+            });
+        }
 
         await db.SaveChangesAsync(ct);
-        logger.LogInformation("Generated digest {Date} with {Count} items", date, top.Count);
+        logger.LogInformation("Generated {Kind} digest {Date} with {Count} items", kind, date, top.Count);
+
+        if (kind != DigestKind.Main) return;
 
         var dispatcher = scope.ServiceProvider.GetRequiredService<IDeliveryDispatcher>();
         var deliveryItems = digest.Items

--- a/src/PBA.Infrastructure/Services/Radar/DigestService.cs
+++ b/src/PBA.Infrastructure/Services/Radar/DigestService.cs
@@ -65,9 +65,9 @@ public sealed class DigestService(
         var query = db.Ideas
             .Where(i => i.ScoredAt != null && i.Score != null && i.DuplicateOfId == null && i.DetectedAt >= since);
 
-        // "Pure Microsoft" = items whose source is tagged Microsoft (set in IdeaSourceSeedService).
+        // "Pure Microsoft" = items from a Microsoft-owned source (flag, not topical category).
         if (kind == DigestKind.Microsoft)
-            query = query.Where(i => i.IdeaSource != null && i.IdeaSource.Category == "Microsoft");
+            query = query.Where(i => i.IdeaSource != null && i.IdeaSource.IsMicrosoftSource);
 
         var top = await query
             .OrderByDescending(i => i.Score)

--- a/src/PBA.Infrastructure/Services/Radar/DigestWriter.cs
+++ b/src/PBA.Infrastructure/Services/Radar/DigestWriter.cs
@@ -4,6 +4,7 @@ using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using PBA.Application.Common.Interfaces;
+using PBA.Domain.Enums;
 using PBA.Infrastructure.Configuration;
 
 namespace PBA.Infrastructure.Services.Radar;
@@ -20,11 +21,12 @@ public sealed class DigestWriter(
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
 
-    public async Task<DigestCopy?> WriteAsync(IReadOnlyList<DigestInput> items, CancellationToken ct = default)
+    public async Task<DigestCopy?> WriteAsync(
+        IReadOnlyList<DigestInput> items, DigestKind kind = DigestKind.Main, CancellationToken ct = default)
     {
         if (items.Count == 0) return null;
 
-        var response = await sidecar.SendPromptAsync(System, BuildUser(items), _options.Model, ct);
+        var response = await sidecar.SendPromptAsync(SystemFor(kind), BuildUser(items), _options.Model, ct);
 
         try
         {
@@ -47,12 +49,29 @@ public sealed class DigestWriter(
     // Honors the brand rule: no em-dashes in Matt-facing copy.
     private static string Clean(string s) => s.Replace('—', '-').Replace('–', '-');
 
-    private const string System =
+    private static string SystemFor(DigestKind kind) => kind == DigestKind.Microsoft ? MicrosoftSystem : MainSystem;
+
+    private const string MainSystem =
         """
         You write a daily AI news brief for Matt Kruczek, an enterprise AI thought leader, in his voice:
         direct, developer-to-executive, no hype, no filler. Given the day's top items, write a short intro
         (2-3 sentences) and a one-sentence "why it matters" for each item, framed around the content angle
         Matt could take. Never use em-dashes or en-dashes. Plain language only.
+
+        Respond with ONLY JSON, no fences:
+        {"title": "short title", "intro": "2-3 sentences",
+         "items": [{"index": 0, "whyItMatters": "one sentence"}]}
+        Include one items entry per input index.
+        """;
+
+    private const string MicrosoftSystem =
+        """
+        You write a daily Microsoft-ecosystem brief for Matt Kruczek, an enterprise AI thought leader, in
+        his voice: direct, developer-to-executive, no hype, no filler. Every item is from a Microsoft-owned
+        source (Azure, .NET, GitHub, Microsoft Research, the corporate and dev blogs). Write a short intro
+        (2-3 sentences) on what Microsoft is shipping or signaling today, and a one-sentence "why it matters"
+        for each item, framed around the angle Matt could take for an enterprise audience. Never use em-dashes
+        or en-dashes. Plain language only.
 
         Respond with ONLY JSON, no fences:
         {"title": "short title", "intro": "2-3 sentences",

--- a/src/PersonalBrandAssistant.Web/nginx.conf
+++ b/src/PersonalBrandAssistant.Web/nginx.conf
@@ -36,7 +36,10 @@ http {
         add_header X-Frame-Options "DENY" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' ws: wss:;" always;
+        # script-src stays 'self' (no 'unsafe-inline'): inline handlers in rendered RSS/article
+        # HTML are untrusted and must stay blocked. Fonts come from Google Fonts (index.html link);
+        # img allows https: because the feed shows article images from arbitrary third-party domains.
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com data:; connect-src 'self' ws: wss:;" always;
 
         location /api/ {
             proxy_pass http://api:8080/api/;

--- a/src/PersonalBrandAssistant.Web/src/app/features/digest/components/brief-detail/brief-detail.component.ts
+++ b/src/PersonalBrandAssistant.Web/src/app/features/digest/components/brief-detail/brief-detail.component.ts
@@ -48,7 +48,7 @@ import { ScoreBadgeComponent } from '../../../../shared/score-badge/score-badge.
     } @else {
       <div class="empty" data-testid="brief-empty">
         <i class="pi pi-inbox"></i>
-        <p>No brief selected yet.</p>
+        <p>{{ emptyMessage() }}</p>
       </div>
     }
   `,
@@ -80,6 +80,7 @@ import { ScoreBadgeComponent } from '../../../../shared/score-badge/score-badge.
 })
 export class BriefDetailComponent {
   readonly digest = input.required<Digest | null>();
+  readonly emptyMessage = input('No brief selected yet.');
   readonly hero = computed(() => this.digest()?.items.find((i) => i.rank === 1) ?? null);
   readonly rest = computed(() => (this.digest()?.items ?? []).filter((i) => i.rank !== 1));
 }

--- a/src/PersonalBrandAssistant.Web/src/app/features/digest/models/digest.model.ts
+++ b/src/PersonalBrandAssistant.Web/src/app/features/digest/models/digest.model.ts
@@ -1,3 +1,5 @@
+export type DigestKind = 'main' | 'microsoft';
+
 export interface DigestItem {
   ideaId: string;
   rank: number;

--- a/src/PersonalBrandAssistant.Web/src/app/features/digest/pages/daily-brief/daily-brief.component.spec.ts
+++ b/src/PersonalBrandAssistant.Web/src/app/features/digest/pages/daily-brief/daily-brief.component.spec.ts
@@ -9,6 +9,8 @@ const summaries: DigestSummary[] = [
 ];
 const latest: Digest = { id: 'd2', date: '2026-06-06', title: 'Today', intro: 'i', itemCount: 1,
   createdAt: '2026-06-06T07:00:00Z', items: [{ ideaId: 'a', rank: 1, score: 9, whyItMatters: 'w', title: 'First', url: null }] };
+const msLatest: Digest = { id: 'm2', date: '2026-06-06', title: 'MS Today', intro: 'i', itemCount: 1,
+  createdAt: '2026-06-06T07:00:00Z', items: [{ ideaId: 'x', rank: 1, score: 9, whyItMatters: 'w', title: 'Azure thing', url: null }] };
 
 describe('DailyBriefComponent', () => {
   let fixture: ComponentFixture<DailyBriefComponent>;
@@ -25,30 +27,39 @@ describe('DailyBriefComponent', () => {
 
   afterEach(() => http.verify());
 
-  function flushInit() {
+  const expectKind = (url: string, kind: string) =>
+    http.expectOne(r => r.url === url && r.params.get('kind') === kind);
+
+  function flushInit(ms: Digest | null = msLatest) {
     http.expectOne('/api/digests').flush(summaries);
-    http.expectOne('/api/digests/latest').flush(latest);
+    expectKind('/api/digests/latest', 'main').flush(latest);
+    expectKind('/api/digests/by-date/2026-06-06', 'microsoft').flush(ms);
     fixture.detectChanges();
   }
 
-  it('loads history and the latest brief on init', () => {
+  it('loads history, the latest brief, and the Microsoft brief side by side', () => {
     flushInit();
     expect(fixture.nativeElement.querySelectorAll('[data-testid="history-entry"]').length).toBe(2);
-    expect(fixture.nativeElement.querySelector('[data-testid="brief-hero"]').textContent).toContain('First');
+    const heroes = fixture.nativeElement.querySelectorAll('[data-testid="brief-hero"]');
+    expect(heroes.length).toBe(2); // main + microsoft columns
+    expect(fixture.nativeElement.textContent).toContain('First');
+    expect(fixture.nativeElement.textContent).toContain('Azure thing');
   });
 
-  it('loads a brief by id when a history entry is selected', () => {
+  it('loads both briefs by date when a history entry is selected', () => {
     flushInit();
     fixture.componentInstance.onSelect('d1');
-    const req = http.expectOne('/api/digests/d1');
-    req.flush({ ...latest, id: 'd1', title: 'Yesterday', items: [{ ideaId: 'b', rank: 1, score: 5, whyItMatters: 'w', title: 'Old', url: null }] });
+    http.expectOne('/api/digests/d1').flush({ ...latest, id: 'd1', title: 'Yesterday', date: '2026-06-05',
+      items: [{ ideaId: 'b', rank: 1, score: 5, whyItMatters: 'w', title: 'Old', url: null }] });
+    expectKind('/api/digests/by-date/2026-06-05', 'microsoft').flush(null); // no MS brief that day
     fixture.detectChanges();
-    expect(fixture.nativeElement.querySelector('[data-testid="brief-hero"]').textContent).toContain('Old');
+    expect(fixture.nativeElement.textContent).toContain('Old');
+    expect(fixture.nativeElement.textContent).toContain('No Microsoft brief for this day.');
   });
 
   it('shows empty state when there are no briefs', () => {
     http.expectOne('/api/digests').flush([]);
-    http.expectOne('/api/digests/latest').flush(null);
+    expectKind('/api/digests/latest', 'main').flush(null); // null date → no Microsoft request fired
     fixture.detectChanges();
     expect(fixture.nativeElement.querySelector('[data-testid="brief-empty"]')).toBeTruthy();
   });

--- a/src/PersonalBrandAssistant.Web/src/app/features/digest/pages/daily-brief/daily-brief.component.ts
+++ b/src/PersonalBrandAssistant.Web/src/app/features/digest/pages/daily-brief/daily-brief.component.ts
@@ -17,7 +17,14 @@ import { BriefDetailComponent } from '../../components/brief-detail/brief-detail
         @if (loading()) {
           <div class="loading">Loading brief…</div>
         } @else {
-          <app-brief-detail [digest]="current()" />
+          <section class="brief-col">
+            <header class="col-head"><span class="col-tag main">AI Brief</span></header>
+            <app-brief-detail [digest]="current()" />
+          </section>
+          <section class="brief-col ms-col">
+            <header class="col-head"><span class="col-tag ms">Microsoft</span></header>
+            <app-brief-detail [digest]="microsoft()" emptyMessage="No Microsoft brief for this day." />
+          </section>
         }
       </main>
     </div>
@@ -25,33 +32,62 @@ import { BriefDetailComponent } from '../../components/brief-detail/brief-detail
   styles: [`
     .brief-layout { display: grid; grid-template-columns: 260px 1fr; height: 100%; min-height: 0; }
     .history-pane { border-right: 1px solid var(--surface-border); overflow-y: auto; background: var(--surface-sidebar); }
-    .detail-pane { overflow-y: auto; }
-    .loading { padding: 48px; text-align: center; color: var(--text-secondary); }
+    .detail-pane { overflow-y: auto; display: grid; grid-template-columns: 1fr 1fr; }
+    .brief-col { min-width: 0; }
+    .ms-col { border-left: 1px solid var(--surface-border); }
+    .col-head { padding: 16px 28px 0; }
+    .col-tag { display: inline-block; font-size: 11px; font-weight: 600; letter-spacing: 0.05em; text-transform: uppercase;
+      padding: 3px 10px; border-radius: var(--r-pill); }
+    .col-tag.main { background: var(--accent-soft); color: var(--brand-primary); }
+    .col-tag.ms { background: color-mix(in srgb, #60a5fa 16%, transparent); color: #60a5fa; }
+    .loading { padding: 48px; text-align: center; color: var(--text-secondary); grid-column: 1 / -1; }
+    @media (max-width: 1024px) {
+      .detail-pane { grid-template-columns: 1fr; }
+      .ms-col { border-left: none; border-top: 1px solid var(--surface-border); }
+    }
   `],
 })
 export class DailyBriefComponent implements OnInit {
   private readonly service = inject(DigestService);
   readonly history = signal<DigestSummary[]>([]);
   readonly current = signal<Digest | null>(null);
+  readonly microsoft = signal<Digest | null>(null);
   readonly selectedId = signal<string | null>(null);
   readonly loading = signal(false);
 
   ngOnInit(): void {
     this.loading.set(true);
     this.service.list().subscribe({ next: (h) => this.history.set(h), error: () => this.history.set([]) });
-    this.service.getLatest().subscribe({
-      next: (d) => { this.current.set(d); this.selectedId.set(d?.id ?? null); this.loading.set(false); },
-      error: () => { this.current.set(null); this.loading.set(false); },
+    this.service.getLatest('main').subscribe({
+      next: (d) => {
+        this.current.set(d);
+        this.selectedId.set(d?.id ?? null);
+        this.loading.set(false);
+        this.loadMicrosoft(d?.date ?? null);
+      },
+      error: () => { this.current.set(null); this.microsoft.set(null); this.loading.set(false); },
     });
   }
 
   onSelect(id: string): void {
     if (id === this.selectedId()) return;
     this.selectedId.set(id);
+    const date = this.history().find((h) => h.id === id)?.date ?? null;
     this.loading.set(true);
     this.service.getById(id).subscribe({
       next: (d) => { this.current.set(d); this.loading.set(false); },
       error: () => { this.current.set(null); this.loading.set(false); },
+    });
+    this.loadMicrosoft(date);
+  }
+
+  // The Microsoft brief shares the Main brief's date; it may not exist (empty source set) — treat 404 as absent.
+  private loadMicrosoft(date: string | null): void {
+    if (!date) { this.microsoft.set(null); return; }
+    const day = date.slice(0, 10); // yyyy-MM-dd for the by-date route
+    this.service.getByDate(day, 'microsoft').subscribe({
+      next: (d) => this.microsoft.set(d),
+      error: () => this.microsoft.set(null),
     });
   }
 }

--- a/src/PersonalBrandAssistant.Web/src/app/features/digest/services/digest.service.spec.ts
+++ b/src/PersonalBrandAssistant.Web/src/app/features/digest/services/digest.service.spec.ts
@@ -17,9 +17,21 @@ describe('DigestService', () => {
 
   afterEach(() => httpMock.verify());
 
-  it('fetches the latest digest', () => {
+  it('fetches the latest digest with the kind param', () => {
+    service.getLatest('microsoft').subscribe();
+    const req = httpMock.expectOne(r => r.url === '/api/digests/latest' && r.params.get('kind') === 'microsoft');
+    expect(req.request.method).toBe('GET');
+    req.flush({ id: '1', date: '2026-06-05', title: 't', intro: 'i', itemCount: 0, createdAt: '', items: [] });
+  });
+
+  it('defaults getLatest to the main kind', () => {
     service.getLatest().subscribe();
-    const req = httpMock.expectOne('/api/digests/latest');
+    httpMock.expectOne(r => r.url === '/api/digests/latest' && r.params.get('kind') === 'main').flush(null);
+  });
+
+  it('fetches a digest by date and kind', () => {
+    service.getByDate('2026-06-05', 'microsoft').subscribe();
+    const req = httpMock.expectOne(r => r.url === '/api/digests/by-date/2026-06-05' && r.params.get('kind') === 'microsoft');
     expect(req.request.method).toBe('GET');
     req.flush({ id: '1', date: '2026-06-05', title: 't', intro: 'i', itemCount: 0, createdAt: '', items: [] });
   });

--- a/src/PersonalBrandAssistant.Web/src/app/features/digest/services/digest.service.ts
+++ b/src/PersonalBrandAssistant.Web/src/app/features/digest/services/digest.service.ts
@@ -1,15 +1,20 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { Digest, DigestSummary } from '../models/digest.model';
+import { Digest, DigestKind, DigestSummary } from '../models/digest.model';
 
 @Injectable({ providedIn: 'root' })
 export class DigestService {
   private readonly http = inject(HttpClient);
   private readonly baseUrl = '/api/digests';
 
-  getLatest(): Observable<Digest> {
-    return this.http.get<Digest>(`${this.baseUrl}/latest`);
+  getLatest(kind: DigestKind = 'main'): Observable<Digest> {
+    return this.http.get<Digest>(`${this.baseUrl}/latest`, { params: { kind } });
+  }
+
+  /** Fetch a specific date's brief for a kind — used to load the Microsoft brief beside the selected Main one. */
+  getByDate(date: string, kind: DigestKind): Observable<Digest> {
+    return this.http.get<Digest>(`${this.baseUrl}/by-date/${date}`, { params: { kind } });
   }
 
   getById(id: string): Observable<Digest> {

--- a/src/PersonalBrandAssistant.Web/src/app/features/news/components/feed/news-feed-item.component.ts
+++ b/src/PersonalBrandAssistant.Web/src/app/features/news/components/feed/news-feed-item.component.ts
@@ -1,5 +1,4 @@
-import { Component, inject, input, output, computed, signal, ViewEncapsulation } from '@angular/core';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { Component, input, output, computed, signal, ViewEncapsulation } from '@angular/core';
 import { marked } from 'marked';
 import { RelativeTimePipe } from '../../../../shared/pipes/relative-time.pipe';
 import { NewsFeedItem, CATEGORY_COLORS, CATEGORY_ICONS } from '../../models/news.model';
@@ -224,8 +223,6 @@ import { NewsFeedItem, CATEGORY_COLORS, CATEGORY_ICONS } from '../../models/news
   `,
 })
 export class NewsFeedItemComponent {
-  private readonly sanitizer = inject(DomSanitizer);
-
   item = input.required<NewsFeedItem>();
   bookmarked = output<void>();
   dismissed = output<void>();
@@ -233,11 +230,12 @@ export class NewsFeedItemComponent {
   readonly showSummary = signal(false);
   readonly categoryColor = computed(() => CATEGORY_COLORS[this.item().sourceCategory] ?? '#6b7280');
   readonly categoryIcon = computed(() => CATEGORY_ICONS[this.item().sourceCategory] ?? 'pi pi-th-large');
-  readonly renderedSummary = computed((): SafeHtml => {
+  // Return parsed-markdown HTML as a plain string so Angular's [innerHTML] sanitizer strips scripts
+  // and inline event handlers (summaries are LLM-generated — untrusted) while keeping formatting.
+  readonly renderedSummary = computed((): string => {
     const md = this.item().summary;
     if (!md) return '';
-    const html = marked.parse(md, { async: false }) as string;
-    return this.sanitizer.bypassSecurityTrustHtml(html);
+    return marked.parse(md, { async: false }) as string;
   });
 
   toggleSummary() {

--- a/src/PersonalBrandAssistant.Web/src/app/features/news/components/feed/news-feed-video-card.component.ts
+++ b/src/PersonalBrandAssistant.Web/src/app/features/news/components/feed/news-feed-video-card.component.ts
@@ -1,5 +1,4 @@
-import { Component, inject, input, output, computed, signal, ViewEncapsulation } from '@angular/core';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { Component, input, output, computed, signal, ViewEncapsulation } from '@angular/core';
 import { marked } from 'marked';
 import { RelativeTimePipe } from '../../../../shared/pipes/relative-time.pipe';
 import { NewsFeedItem, CATEGORY_COLORS, CATEGORY_ICONS } from '../../models/news.model';
@@ -287,8 +286,6 @@ import { NewsFeedItem, CATEGORY_COLORS, CATEGORY_ICONS } from '../../models/news
   `,
 })
 export class NewsFeedVideoCardComponent {
-  private readonly sanitizer = inject(DomSanitizer);
-
   item = input.required<NewsFeedItem>();
   bookmarked = output<void>();
   dismissed = output<void>();
@@ -297,11 +294,12 @@ export class NewsFeedVideoCardComponent {
   readonly showSummary = signal(false);
   readonly categoryColor = computed(() => CATEGORY_COLORS[this.item().sourceCategory] ?? '#6b7280');
   readonly categoryIcon = computed(() => CATEGORY_ICONS[this.item().sourceCategory] ?? 'pi pi-th-large');
-  readonly renderedSummary = computed((): SafeHtml => {
+  // Return parsed-markdown HTML as a plain string so Angular's [innerHTML] sanitizer strips scripts
+  // and inline event handlers (summaries are LLM-generated — untrusted) while keeping formatting.
+  readonly renderedSummary = computed((): string => {
     const md = this.item().summary;
     if (!md) return '';
-    const html = marked.parse(md, { async: false }) as string;
-    return this.sanitizer.bypassSecurityTrustHtml(html);
+    return marked.parse(md, { async: false }) as string;
   });
 
   toggleSummary() {

--- a/src/PersonalBrandAssistant.Web/src/app/features/news/components/feed/news-feed.component.ts
+++ b/src/PersonalBrandAssistant.Web/src/app/features/news/components/feed/news-feed.component.ts
@@ -19,15 +19,15 @@ import { CATEGORY_COLORS, CATEGORY_ICONS, CategoryGroup, SOURCE_COLORS, SOURCE_I
       <app-news-feed-filters style="flex: 1;" />
       <div class="view-toggle" role="group" aria-label="Feed view">
         <p-button
-          icon="pi pi-objects-column" size="small"
-          [severity]="store.rankedView() ? 'secondary' : 'primary'" [text]="store.rankedView()"
-          pTooltip="Grouped by category" (onClick)="store.setRankedView(false)"
+          label="Grouped" icon="pi pi-th-large" size="small"
+          [outlined]="store.rankedView()"
+          pTooltip="Group by category" (onClick)="store.setRankedView(false)"
           data-testid="grouped-toggle"
         />
         <p-button
-          icon="pi pi-sort-amount-down" size="small"
-          [severity]="store.rankedView() ? 'primary' : 'secondary'" [text]="!store.rankedView()"
-          pTooltip="Ranked by brand fit" (onClick)="store.setRankedView(true)"
+          label="Ranked" icon="pi pi-sort-amount-down" size="small"
+          [outlined]="!store.rankedView()"
+          pTooltip="Sort by brand fit" (onClick)="store.setRankedView(true)"
           data-testid="ranked-toggle"
         />
       </div>

--- a/src/PersonalBrandAssistant.Web/src/app/features/news/components/feed/news-feed.component.ts
+++ b/src/PersonalBrandAssistant.Web/src/app/features/news/components/feed/news-feed.component.ts
@@ -6,22 +6,39 @@ import { NewsStore } from '../../store/news.store';
 import { NewsFeedFiltersComponent } from './news-feed-filters.component';
 import { NewsFeedItemComponent } from './news-feed-item.component';
 import { NewsFeedVideoCardComponent } from './news-feed-video-card.component';
+import { ScoreBadgeComponent } from '../../../../shared/score-badge/score-badge.component';
 import { CATEGORY_COLORS, CATEGORY_ICONS, CategoryGroup, SOURCE_COLORS, SOURCE_ICONS, GroupMode } from '../../models/news.model';
 
 @Component({
   selector: 'app-news-feed',
   standalone: true,
   encapsulation: ViewEncapsulation.None,
-  imports: [ButtonModule, SkeletonModule, Tooltip, NewsFeedFiltersComponent, NewsFeedItemComponent, NewsFeedVideoCardComponent],
+  imports: [ButtonModule, SkeletonModule, Tooltip, NewsFeedFiltersComponent, NewsFeedItemComponent, NewsFeedVideoCardComponent, ScoreBadgeComponent],
   template: `
     <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 1.25rem;">
       <app-news-feed-filters style="flex: 1;" />
-      <p-button
-        [icon]="allCollapsed() ? 'pi pi-angle-double-down' : 'pi pi-angle-double-up'"
-        [text]="true" size="small"
-        [pTooltip]="allCollapsed() ? 'Expand all' : 'Collapse all'"
-        (onClick)="toggleAllCollapse()"
-      />
+      <div class="view-toggle" role="group" aria-label="Feed view">
+        <p-button
+          icon="pi pi-objects-column" size="small"
+          [severity]="store.rankedView() ? 'secondary' : 'primary'" [text]="store.rankedView()"
+          pTooltip="Grouped by category" (onClick)="store.setRankedView(false)"
+          data-testid="grouped-toggle"
+        />
+        <p-button
+          icon="pi pi-sort-amount-down" size="small"
+          [severity]="store.rankedView() ? 'primary' : 'secondary'" [text]="!store.rankedView()"
+          pTooltip="Ranked by brand fit" (onClick)="store.setRankedView(true)"
+          data-testid="ranked-toggle"
+        />
+      </div>
+      @if (!store.rankedView()) {
+        <p-button
+          [icon]="allCollapsed() ? 'pi pi-angle-double-down' : 'pi pi-angle-double-up'"
+          [text]="true" size="small"
+          [pTooltip]="allCollapsed() ? 'Expand all' : 'Collapse all'"
+          (onClick)="toggleAllCollapse()"
+        />
+      }
       <p-button
         icon="pi pi-refresh" label="Refresh" [text]="true" size="small"
         [loading]="store.refreshing()" (onClick)="store.refresh(undefined)"
@@ -34,6 +51,37 @@ import { CATEGORY_COLORS, CATEGORY_ICONS, CategoryGroup, SOURCE_COLORS, SOURCE_I
           <p-skeleton height="100px" borderRadius="12px" />
         }
       </div>
+    } @else if (store.rankedView()) {
+      @if (store.rankedItems().length === 0) {
+        <div class="ranked-feed__empty" data-testid="ranked-empty">No articles match your filters.</div>
+      } @else {
+        <ol class="ranked-feed">
+          @for (item of store.rankedItems(); track item.id; let i = $index) {
+            <li class="ranked-feed__row" data-testid="ranked-row">
+              <div class="ranked-feed__lead">
+                <span class="ranked-feed__numeral">{{ i + 1 }}</span>
+                <app-score-badge [score]="item.score ?? 0" />
+                @if (item.stale) { <span class="ranked-feed__stale">Stale</span> }
+              </div>
+              <div class="ranked-feed__card">
+                @if (item.thumbnailUrl) {
+                  <app-news-feed-video-card
+                    [item]="item"
+                    (bookmarked)="store.toggleSaved(item.id)"
+                    (dismissed)="store.dismiss(item.id)"
+                  />
+                } @else {
+                  <app-news-feed-item
+                    [item]="item"
+                    (bookmarked)="store.toggleSaved(item.id)"
+                    (dismissed)="store.dismiss(item.id)"
+                  />
+                }
+              </div>
+            </li>
+          }
+        </ol>
+      }
     } @else if (groups().length === 0) {
       <div style="
         border: 1px dashed rgba(139,92,246,0.2); border-radius: 16px;
@@ -149,6 +197,27 @@ import { CATEGORY_COLORS, CATEGORY_ICONS, CategoryGroup, SOURCE_COLORS, SOURCE_I
     }
   `,
   styles: `
+    .view-toggle { display: flex; gap: 4px; }
+
+    .ranked-feed { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.75rem; }
+    .ranked-feed__row { display: flex; gap: 0.75rem; align-items: flex-start; }
+    .ranked-feed__lead {
+      display: flex; flex-direction: column; align-items: center; gap: 0.4rem;
+      min-width: 40px; padding-top: 0.25rem;
+    }
+    .ranked-feed__numeral {
+      font-size: 1.25rem; font-weight: 700; line-height: 1;
+      color: var(--brand-primary, #8b5cf6);
+    }
+    .ranked-feed__stale {
+      font-size: 0.55rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em;
+      padding: 0.1rem 0.35rem; border-radius: 999px;
+      background: color-mix(in srgb, var(--score-warning, #f59e0b) 18%, transparent);
+      color: var(--score-warning, #f59e0b);
+    }
+    .ranked-feed__card { flex: 1; min-width: 0; }
+    .ranked-feed__empty { padding: 3rem; text-align: center; color: rgba(255, 255, 255, 0.4); }
+
     .category-section__header {
       display: flex;
       align-items: center;

--- a/src/PersonalBrandAssistant.Web/src/app/features/news/models/news.model.ts
+++ b/src/PersonalBrandAssistant.Web/src/app/features/news/models/news.model.ts
@@ -16,6 +16,11 @@ export interface NewsFeedItem {
   readonly saved: boolean;
   readonly summary?: string;
   readonly tags: readonly string[];
+  // Brand-anchored ranking (section-08 IdeaDto), carried through so the feed can offer a Ranked view.
+  readonly rank: number;
+  readonly brandFit: number;
+  readonly score: number | null;
+  readonly stale: boolean;
 }
 
 export function ideaToFeedItem(idea: Idea): NewsFeedItem {
@@ -34,6 +39,10 @@ export function ideaToFeedItem(idea: Idea): NewsFeedItem {
     saved: idea.status === IdeaStatus.Saved,
     summary: idea.summary ?? undefined,
     tags: idea.tags,
+    rank: idea.rank,
+    brandFit: idea.brandFit,
+    score: idea.score,
+    stale: idea.stale,
   };
 }
 

--- a/src/PersonalBrandAssistant.Web/src/app/features/news/store/news-ranked.spec.ts
+++ b/src/PersonalBrandAssistant.Web/src/app/features/news/store/news-ranked.spec.ts
@@ -1,0 +1,103 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { MessageService } from 'primeng/api';
+import { NewsStore } from './news.store';
+import { IdeaStatus } from '../../../models/idea.model';
+import type { Idea } from '../../../models/idea.model';
+import type { PagedResult } from '../../../models/pagination.model';
+
+describe('NewsStore ranked view', () => {
+  let store: InstanceType<typeof NewsStore>;
+  let httpMock: HttpTestingController;
+
+  const makeIdea = (id: string, rank: number, detectedAt: string): Idea => ({
+    id,
+    title: `Story ${id}`,
+    sourceName: 'TestSource',
+    category: 'AI/ML',
+    summary: 'desc',
+    thumbnailUrl: null,
+    status: IdeaStatus.New,
+    tags: [],
+    detectedAt,
+    hasSavedDetails: false,
+    description: null,
+    url: `https://example.com/${id}`,
+    score: Math.round(rank * 10),
+    scoreReason: null,
+    isDuplicate: false,
+    rank,
+    brandFit: rank,
+    pillarBreakdown: [],
+    isAntiTopic: null,
+    isAuthorityTopic: null,
+    recencyFactor: 0,
+    stale: false,
+  });
+
+  const flushIdeasLoad = (ideas: Idea[]) => {
+    const page: PagedResult<Idea> = {
+      items: ideas, totalCount: ideas.length, page: 1, pageSize: 5000, totalPages: 1,
+    };
+    httpMock.expectOne(r => r.url.includes('/api/ideas')).flush(page);
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        NewsStore,
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: MessageService, useValue: jasmine.createSpyObj('MessageService', ['add']) },
+      ],
+    });
+    store = TestBed.inject(NewsStore);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('rankedItems orders the filtered feed by rank descending', () => {
+    const now = Date.now();
+    store.load(undefined);
+    flushIdeasLoad([
+      makeIdea('low', 0.2, new Date(now).toISOString()),
+      makeIdea('high', 0.9, new Date(now).toISOString()),
+      makeIdea('mid', 0.5, new Date(now).toISOString()),
+    ]);
+
+    expect(store.rankedItems().map(i => i.id)).toEqual(['high', 'mid', 'low']);
+  });
+
+  it('breaks rank ties by recency (newer first)', () => {
+    const now = Date.now();
+    store.load(undefined);
+    flushIdeasLoad([
+      makeIdea('older', 0.5, new Date(now - 60_000).toISOString()),
+      makeIdea('newer', 0.5, new Date(now).toISOString()),
+    ]);
+
+    expect(store.rankedItems().map(i => i.id)).toEqual(['newer', 'older']);
+  });
+
+  it('rankedItems respects the active category filter', () => {
+    const now = new Date().toISOString();
+    store.load(undefined);
+    const aiml = makeIdea('aiml', 0.9, now);
+    const sec = { ...makeIdea('sec', 0.95, now), category: 'Security' };
+    flushIdeasLoad([aiml, sec]);
+
+    store.updateFilters({ categories: ['AI/ML'] });
+
+    expect(store.rankedItems().map(i => i.id)).toEqual(['aiml']);
+  });
+
+  it('setRankedView toggles the view flag', () => {
+    expect(store.rankedView()).toBe(false);
+    store.setRankedView(true);
+    expect(store.rankedView()).toBe(true);
+    store.setRankedView(false);
+    expect(store.rankedView()).toBe(false);
+  });
+});

--- a/src/PersonalBrandAssistant.Web/src/app/features/news/store/news.store.ts
+++ b/src/PersonalBrandAssistant.Web/src/app/features/news/store/news.store.ts
@@ -42,6 +42,7 @@ interface NewsState {
   readonly collapsedSources: ReadonlySet<string>;
   readonly filters: NewsFeedFilters;
   readonly groupMode: GroupMode;
+  readonly rankedView: boolean;
   readonly loading: boolean;
   readonly refreshing: boolean;
   readonly lastRefreshDelta: number;
@@ -58,6 +59,7 @@ const initialState: NewsState = {
     showSavedOnly: false,
   },
   groupMode: 'category' as GroupMode,
+  rankedView: false,
   loading: false,
   refreshing: false,
   lastRefreshDelta: 0,
@@ -100,6 +102,15 @@ export const NewsStore = signalStore(
     return {
       allItems,
       filteredItems,
+      // Flat, brand-rank-ordered view of the same filtered feed (highest rank first; recency breaks ties).
+      // Unscored items (rank 0) naturally sink to the bottom and float up as the scoring sweep completes.
+      rankedItems: computed(() =>
+        [...filteredItems()].sort(
+          (a, b) =>
+            b.rank - a.rank ||
+            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+        )
+      ),
       groupedByCategory: computed(() => {
         const items = filteredItems();
         const grouped = new Map<string, NewsFeedItem[]>();
@@ -265,6 +276,10 @@ export const NewsStore = signalStore(
     toggleGroupMode() {
       const next: GroupMode = store.groupMode() === 'category' ? 'source' : 'category';
       patchState(store, { groupMode: next, collapsedCategories: new Set<string>(), collapsedSources: new Set<string>() });
+    },
+
+    setRankedView(rankedView: boolean) {
+      patchState(store, { rankedView });
     },
   }))
 );

--- a/tests/PBA.Api.Tests/Endpoints/DigestEndpointsTests.cs
+++ b/tests/PBA.Api.Tests/Endpoints/DigestEndpointsTests.cs
@@ -32,4 +32,23 @@ public class DigestEndpointsTests : IClassFixture<TestWebApplicationFactory>
         var body = await response.Content.ReadFromJsonAsync<IReadOnlyList<DigestSummaryDto>>();
         Assert.NotNull(body);
     }
+
+    [Fact]
+    public async Task GetLatest_MicrosoftKind_BindsAndReaches404WhenAbsent()
+    {
+        var response = await _client.GetAsync("/api/digests/latest?kind=microsoft");
+        Assert.True(
+            response.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.BadRequest,
+            $"Expected 404 or 400, got {(int)response.StatusCode}");
+    }
+
+    [Fact]
+    public async Task GetByDate_BindsDateAndKind_Reaches404WhenAbsent()
+    {
+        // Proves the {date:datetime} route + kind query bind and reach the handler (not a routing 404).
+        var response = await _client.GetAsync("/api/digests/by-date/2026-06-06?kind=microsoft");
+        Assert.True(
+            response.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.BadRequest,
+            $"Expected 404 or 400, got {(int)response.StatusCode}");
+    }
 }

--- a/tests/PBA.Api.Tests/Endpoints/ExternalEndpointsTests.cs
+++ b/tests/PBA.Api.Tests/Endpoints/ExternalEndpointsTests.cs
@@ -1,0 +1,163 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Moq;
+using PBA.Api.Authentication;
+using PBA.Api.Endpoints;
+using PBA.Application.Common.Interfaces;
+using PBA.Application.Features.Analytics.Dtos;
+using PBA.Domain.Common;
+using Xunit;
+
+namespace PBA.Api.Tests.Endpoints;
+
+public class ExternalEndpointsTests : IClassFixture<TestWebApplicationFactory>
+{
+    private const string ValidKey = "test-external-key-123";
+    private readonly TestWebApplicationFactory _factory;
+
+    public ExternalEndpointsTests(TestWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    // Client whose host has a configured key. Optionally sends a key header.
+    private HttpClient AuthorizedHost(string? keyHeader, Action<IServiceCollection>? configure = null)
+    {
+        var client = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.UseSetting($"{ExternalApiOptions.SectionName}:ApiKey", ValidKey);
+            if (configure is not null)
+                builder.ConfigureTestServices(configure);
+        }).CreateClient();
+
+        if (keyHeader is not null)
+            client.DefaultRequestHeaders.Add(ApiKeyEndpointFilter.HeaderName, keyHeader);
+
+        return client;
+    }
+
+    [Fact]
+    public async Task Feed_NoApiKey_Returns401()
+    {
+        var client = AuthorizedHost(keyHeader: null);
+        var response = await client.GetAsync("/api/external/feed");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Feed_WrongApiKey_Returns401()
+    {
+        var client = AuthorizedHost(keyHeader: "wrong-key");
+        var response = await client.GetAsync("/api/external/feed");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Feed_KeyNotConfigured_FailsClosed_Returns401()
+    {
+        // Base factory has no ExternalApi:ApiKey set — even a plausible header must be rejected.
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add(ApiKeyEndpointFilter.HeaderName, ValidKey);
+
+        var response = await client.GetAsync("/api/external/feed");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Feed_ValidKey_Returns200()
+    {
+        var client = AuthorizedHost(ValidKey);
+        var response = await client.GetAsync("/api/external/feed");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Ideas_ValidKey_Returns200()
+    {
+        var client = AuthorizedHost(ValidKey);
+        var response = await client.GetAsync("/api/external/ideas");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Content_ValidKey_Returns200()
+    {
+        var client = AuthorizedHost(ValidKey);
+        var response = await client.GetAsync("/api/external/content");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Trending_ValidKey_Returns200()
+    {
+        var client = AuthorizedHost(ValidKey);
+        var response = await client.GetAsync("/api/external/feed/trending");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DigestLatest_ValidKey_PassesAuthAndReachesHandler()
+    {
+        var client = AuthorizedHost(ValidKey);
+        var response = await client.GetAsync("/api/external/digests/latest");
+        // No digest seeded -> handler returns 404/400. The point: auth passed (not 401).
+        Assert.NotEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.True(response.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task AnalyticsWebsite_ValidKey_Returns200()
+    {
+        var ga = new Mock<IGoogleAnalyticsService>();
+        ga.Setup(g => g.GetOverviewAsync(It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<WebsiteOverview>.Success(new WebsiteOverview(1, 1, 1, 1, 0.1, 1)));
+        ga.Setup(g => g.GetTopPagesAsync(It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IReadOnlyList<PageViewEntry>>.Success([]));
+        ga.Setup(g => g.GetTrafficSourcesAsync(It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IReadOnlyList<TrafficSourceEntry>>.Success([]));
+        ga.Setup(g => g.GetTopQueriesAsync(It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IReadOnlyList<SearchQueryEntry>>.Success([]));
+
+        var client = AuthorizedHost(ValidKey, services =>
+        {
+            services.RemoveAll<IGoogleAnalyticsService>();
+            services.AddScoped(_ => ga.Object);
+        });
+
+        var response = await client.GetAsync("/api/external/analytics/website?period=7d");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateIdea_NoApiKey_Returns401()
+    {
+        var client = AuthorizedHost(keyHeader: null);
+        var response = await client.PostAsJsonAsync("/api/external/ideas",
+            new CreateExternalIdeaRequest { Title = "Should not be created" });
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateIdea_ValidKey_Returns201WithId()
+    {
+        var client = AuthorizedHost(ValidKey);
+        var response = await client.PostAsJsonAsync("/api/external/ideas",
+            new CreateExternalIdeaRequest
+            {
+                Title = "Avatar-sourced idea " + Guid.NewGuid(),
+                Description = "Injected by project-avatar",
+                Category = "AI",
+                Tags = ["agents", "branding"]
+            });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<CreatedIdeaResponse>();
+        Assert.NotNull(body);
+        Assert.NotEqual(Guid.Empty, body!.Id);
+    }
+
+    private sealed record CreatedIdeaResponse(Guid Id);
+}

--- a/tests/PBA.Application.Tests/Features/Digests/DigestQueriesTests.cs
+++ b/tests/PBA.Application.Tests/Features/Digests/DigestQueriesTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using PBA.Application.Features.Digests.Queries;
 using PBA.Domain.Entities;
+using PBA.Domain.Enums;
 using PBA.Infrastructure.Data;
 using Xunit;
 
@@ -55,5 +56,66 @@ public class DigestQueriesTests
         var handler = new GetDigest.Handler(db);
         var result = await handler.Handle(new GetDigest.Query(Guid.NewGuid()), default);
         Assert.False(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task GetLatestDigest_MicrosoftKind_ReturnsMicrosoftBriefNotMain()
+    {
+        using var db = NewDb();
+        var date = new DateOnly(2026, 6, 4);
+        db.Digests.AddRange(
+            new Digest { Date = date, Kind = DigestKind.Main, Title = "Main", Intro = "i", CreatedAt = DateTimeOffset.UtcNow },
+            new Digest { Date = date, Kind = DigestKind.Microsoft, Title = "MS", Intro = "i", CreatedAt = DateTimeOffset.UtcNow });
+        await db.SaveChangesAsync();
+
+        var result = await new GetLatestDigest.Handler(db).Handle(new GetLatestDigest.Query(DigestKind.Microsoft), default);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("MS", result.Value!.Title);
+    }
+
+    [Fact]
+    public async Task ListDigests_ExcludesMicrosoftBriefs()
+    {
+        using var db = NewDb();
+        var date = new DateOnly(2026, 6, 4);
+        db.Digests.AddRange(
+            new Digest { Date = date, Kind = DigestKind.Main, Title = "Main", Intro = "i", CreatedAt = DateTimeOffset.UtcNow },
+            new Digest { Date = date, Kind = DigestKind.Microsoft, Title = "MS", Intro = "i", CreatedAt = DateTimeOffset.UtcNow });
+        await db.SaveChangesAsync();
+
+        var result = await new ListDigests.Handler(db).Handle(new ListDigests.Query(), default);
+
+        Assert.Single(result.Value!);
+        Assert.Equal("Main", result.Value![0].Title);
+    }
+
+    [Fact]
+    public async Task GetDigestByDate_ReturnsRequestedDateAndKind()
+    {
+        using var db = NewDb();
+        var date = new DateOnly(2026, 6, 4);
+        db.Digests.AddRange(
+            new Digest { Date = date, Kind = DigestKind.Main, Title = "Main", Intro = "i", CreatedAt = DateTimeOffset.UtcNow },
+            new Digest { Date = date, Kind = DigestKind.Microsoft, Title = "MS", Intro = "i", CreatedAt = DateTimeOffset.UtcNow });
+        await db.SaveChangesAsync();
+
+        var result = await new GetDigestByDate.Handler(db).Handle(new GetDigestByDate.Query(date, DigestKind.Microsoft), default);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("MS", result.Value!.Title);
+    }
+
+    [Fact]
+    public async Task GetDigestByDate_MissingKindForDate_ReturnsFailure()
+    {
+        using var db = NewDb();
+        var date = new DateOnly(2026, 6, 4);
+        db.Digests.Add(new Digest { Date = date, Kind = DigestKind.Main, Title = "Main", Intro = "i", CreatedAt = DateTimeOffset.UtcNow });
+        await db.SaveChangesAsync();
+
+        var result = await new GetDigestByDate.Handler(db).Handle(new GetDigestByDate.Query(date, DigestKind.Microsoft), default);
+
+        Assert.False(result.IsSuccess); // no Microsoft brief that day
     }
 }

--- a/tests/PBA.Infrastructure.Tests/Services/OpenRouterClientEmbedTests.cs
+++ b/tests/PBA.Infrastructure.Tests/Services/OpenRouterClientEmbedTests.cs
@@ -130,6 +130,23 @@ public class OpenRouterClientEmbedTests
     }
 
     [Fact]
+    public async Task EmbedAsync_InputLongerThanMax_IsTruncatedBeforeSend()
+    {
+        // A single over-long input (e.g. a full article body) exceeds the embedding model's per-input
+        // token limit and makes the provider return 0 vectors, failing the whole batch. The client must
+        // cap each input to MaxInputChars before sending so one giant idea never poisons its batch.
+        var embed = new EmbeddingOptions { MaxInputChars = 10 };
+        var handler = new ScriptedHandler((_, input) => EmbeddingsOk(input.Select((_, i) => (i, Vec(i)))));
+        var client = Client(handler, embed);
+
+        await client.EmbedAsync([new string('a', 50)]);
+
+        using var doc = JsonDocument.Parse(handler.CapturedBodies.Single());
+        var sent = doc.RootElement.GetProperty("input").EnumerateArray().Single().GetString()!;
+        Assert.Equal(10, sent.Length);
+    }
+
+    [Fact]
     public async Task EmbedAsync_AllEmptyInputs_ReturnsEmpty_NoHttpCall()
     {
         var handler = new ScriptedHandler((_, _) => throw new Xunit.Sdk.XunitException("should not call API"));

--- a/tests/PBA.Infrastructure.Tests/Services/Radar/DigestServiceTests.cs
+++ b/tests/PBA.Infrastructure.Tests/Services/Radar/DigestServiceTests.cs
@@ -49,10 +49,10 @@ public class DigestServiceTests
         ScoredAt = DateTimeOffset.UtcNow, Summary = "summary", DuplicateOfId = dupOf
     };
 
-    // A scored idea attached to a source tagged for the Microsoft brief.
+    // A scored idea attached to a Microsoft-owned source. Category stays topical; the flag drives the brief.
     private static Idea MicrosoftScored(int score)
     {
-        var source = new IdeaSource { Name = "Azure Blog", Category = "Microsoft", FeedUrl = "https://x/feed" };
+        var source = new IdeaSource { Name = "Azure Blog", Category = "Azure/Cloud", IsMicrosoftSource = true, FeedUrl = "https://x/feed" };
         var idea = Scored(score);
         idea.IdeaSourceId = source.Id;
         idea.IdeaSource = source;

--- a/tests/PBA.Infrastructure.Tests/Services/Radar/DigestServiceTests.cs
+++ b/tests/PBA.Infrastructure.Tests/Services/Radar/DigestServiceTests.cs
@@ -49,6 +49,23 @@ public class DigestServiceTests
         ScoredAt = DateTimeOffset.UtcNow, Summary = "summary", DuplicateOfId = dupOf
     };
 
+    // A scored idea attached to a source tagged for the Microsoft brief.
+    private static Idea MicrosoftScored(int score)
+    {
+        var source = new IdeaSource { Name = "Azure Blog", Category = "Microsoft", FeedUrl = "https://x/feed" };
+        var idea = Scored(score);
+        idea.IdeaSourceId = source.Id;
+        idea.IdeaSource = source;
+        return idea;
+    }
+
+    // Default writer copy covering the first two ranks; extra ranks fall back to empty whyItMatters.
+    private static void SetupWriter(Mock<IDigestWriter> writer) =>
+        writer.Setup(w => w.WriteAsync(It.IsAny<IReadOnlyList<DigestInput>>(), It.IsAny<DigestKind>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<DigestInput> inp, DigestKind kind, CancellationToken _) =>
+                new DigestCopy($"{kind} Brief", "Intro",
+                    inp.Select(i => new DigestItemCopy(i.Index, $"Why {i.Index}")).ToList()));
+
     [Fact]
     public async Task GenerateDigestAsync_TopScoredPrimaries_CreatesDigestItemsAndFeedAlert()
     {
@@ -56,17 +73,11 @@ public class DigestServiceTests
         var a = Scored(9); var b = Scored(7);
         db.Ideas.AddRange(a, b);
         await db.SaveChangesAsync();
-
-        writer.Setup(w => w.WriteAsync(It.IsAny<IReadOnlyList<DigestInput>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new DigestCopy("Brief", "Intro", new List<DigestItemCopy>
-            {
-                new(0, "Why A"), new(1, "Why B")
-            }));
+        SetupWriter(writer);
 
         await svc.GenerateDigestAsync(DateTimeOffset.UtcNow, CancellationToken.None);
 
-        var digest = db.Digests.Include(d => d.Items).Single();
-        Assert.Equal("Brief", digest.Title);
+        var digest = db.Digests.Include(d => d.Items).Single(d => d.Kind == DigestKind.Main);
         Assert.Equal(2, digest.Items.Count);
         Assert.Equal(1, digest.Items.Single(i => i.IdeaId == a.Id).Rank); // highest score ranked 1
         Assert.Equal(2, digest.Items.Single(i => i.IdeaId == b.Id).Rank);
@@ -79,13 +90,12 @@ public class DigestServiceTests
         var (svc, db, writer, dispatcher) = Build(new DigestOptions { TopN = 8, LookbackHours = 24 });
         db.Ideas.AddRange(Scored(9), Scored(7));
         await db.SaveChangesAsync();
-        writer.Setup(w => w.WriteAsync(It.IsAny<IReadOnlyList<DigestInput>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new DigestCopy("Brief", "Intro", new List<DigestItemCopy> { new(0, "Why A"), new(1, "Why B") }));
+        SetupWriter(writer);
 
         await svc.GenerateDigestAsync(DateTimeOffset.UtcNow, CancellationToken.None);
 
         dispatcher.Verify(d => d.DispatchAsync(
-            It.Is<DeliveryNotification>(n => n.Kind == DeliveryKind.Digest && n.Title == "Brief" && n.Items.Count == 2),
+            It.Is<DeliveryNotification>(n => n.Kind == DeliveryKind.Digest && n.Items.Count == 2),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -110,8 +120,8 @@ public class DigestServiceTests
         await db.SaveChangesAsync();
 
         DigestInput[]? captured = null;
-        writer.Setup(w => w.WriteAsync(It.IsAny<IReadOnlyList<DigestInput>>(), It.IsAny<CancellationToken>()))
-            .Callback<IReadOnlyList<DigestInput>, CancellationToken>((inp, _) => captured = inp.ToArray())
+        writer.Setup(w => w.WriteAsync(It.IsAny<IReadOnlyList<DigestInput>>(), It.IsAny<DigestKind>(), It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyList<DigestInput>, DigestKind, CancellationToken>((inp, _, _) => captured = inp.ToArray())
             .ReturnsAsync(new DigestCopy("t", "i", new List<DigestItemCopy> { new(0, "w") }));
 
         await svc.GenerateDigestAsync(DateTimeOffset.UtcNow, CancellationToken.None);
@@ -130,7 +140,8 @@ public class DigestServiceTests
 
         await svc.GenerateDigestAsync(DateTimeOffset.UtcNow, CancellationToken.None);
 
-        writer.Verify(w => w.WriteAsync(It.IsAny<IReadOnlyList<DigestInput>>(), It.IsAny<CancellationToken>()), Times.Never);
+        // Main is guarded by the existing row; no Microsoft-source ideas, so that pass produces nothing.
+        writer.Verify(w => w.WriteAsync(It.IsAny<IReadOnlyList<DigestInput>>(), It.IsAny<DigestKind>(), It.IsAny<CancellationToken>()), Times.Never);
         Assert.Single(db.Digests);
     }
 
@@ -140,7 +151,7 @@ public class DigestServiceTests
         var (svc, db, writer, _) = Build(new DigestOptions());
         await svc.GenerateDigestAsync(DateTimeOffset.UtcNow, CancellationToken.None);
         Assert.Empty(db.Digests);
-        writer.Verify(w => w.WriteAsync(It.IsAny<IReadOnlyList<DigestInput>>(), It.IsAny<CancellationToken>()), Times.Never);
+        writer.Verify(w => w.WriteAsync(It.IsAny<IReadOnlyList<DigestInput>>(), It.IsAny<DigestKind>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -152,21 +163,68 @@ public class DigestServiceTests
         await db.SaveChangesAsync();
 
         // Writer only returns copy for index 0 — index 1 is absent
-        writer.Setup(w => w.WriteAsync(It.IsAny<IReadOnlyList<DigestInput>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new DigestCopy("Brief", "Intro", new List<DigestItemCopy>
-            {
-                new(0, "Why A")
-            }));
+        writer.Setup(w => w.WriteAsync(It.IsAny<IReadOnlyList<DigestInput>>(), It.IsAny<DigestKind>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DigestCopy("Brief", "Intro", new List<DigestItemCopy> { new(0, "Why A") }));
 
         var exception = await Record.ExceptionAsync(() =>
             svc.GenerateDigestAsync(DateTimeOffset.UtcNow, CancellationToken.None));
 
         Assert.Null(exception);
 
-        var digest = db.Digests.Include(d => d.Items).Single();
+        var digest = db.Digests.Include(d => d.Items).Single(d => d.Kind == DigestKind.Main);
         Assert.Equal(2, digest.Items.Count);
 
         var rank2Item = digest.Items.Single(i => i.Rank == 2);
         Assert.Equal(string.Empty, rank2Item.WhyItMatters);
+    }
+
+    [Fact]
+    public async Task GenerateDigestAsync_MicrosoftSourceItems_CreatesMicrosoftDigestWithOnlyThoseItems()
+    {
+        var (svc, db, writer, _) = Build(new DigestOptions { TopN = 8, LookbackHours = 24 });
+        var ms = MicrosoftScored(9);
+        var general = Scored(8); // higher-ranked-looking but not Microsoft-sourced
+        db.Ideas.AddRange(ms, general);
+        await db.SaveChangesAsync();
+        SetupWriter(writer);
+
+        await svc.GenerateDigestAsync(DateTimeOffset.UtcNow, CancellationToken.None);
+
+        var msDigest = db.Digests.Include(d => d.Items).Single(d => d.Kind == DigestKind.Microsoft);
+        Assert.Equal(DigestKind.Microsoft, msDigest.Kind);
+        var item = Assert.Single(msDigest.Items);
+        Assert.Equal(ms.Id, item.IdeaId); // the general idea is excluded from the Microsoft brief
+
+        var mainDigest = db.Digests.Include(d => d.Items).Single(d => d.Kind == DigestKind.Main);
+        Assert.Equal(2, mainDigest.Items.Count); // Main still includes everything
+    }
+
+    [Fact]
+    public async Task GenerateDigestAsync_NoMicrosoftItems_DoesNotCreateMicrosoftDigest()
+    {
+        var (svc, db, writer, _) = Build(new DigestOptions { TopN = 8, LookbackHours = 24 });
+        db.Ideas.AddRange(Scored(9), Scored(7));
+        await db.SaveChangesAsync();
+        SetupWriter(writer);
+
+        await svc.GenerateDigestAsync(DateTimeOffset.UtcNow, CancellationToken.None);
+
+        Assert.DoesNotContain(db.Digests, d => d.Kind == DigestKind.Microsoft);
+    }
+
+    [Fact]
+    public async Task GenerateDigestAsync_MicrosoftBrief_DoesNotDispatchOrAddFeedItem()
+    {
+        var (svc, db, writer, dispatcher) = Build(new DigestOptions { TopN = 8, LookbackHours = 24 });
+        db.Ideas.Add(MicrosoftScored(9)); // ONLY a Microsoft item — Main and Microsoft both build from it
+        await db.SaveChangesAsync();
+        SetupWriter(writer);
+
+        await svc.GenerateDigestAsync(DateTimeOffset.UtcNow, CancellationToken.None);
+
+        // Both briefs exist, but delivery + feed notification fire once (Main only).
+        Assert.Equal(2, db.Digests.Count());
+        dispatcher.Verify(d => d.DispatchAsync(It.IsAny<DeliveryNotification>(), It.IsAny<CancellationToken>()), Times.Once);
+        Assert.Single(db.FeedItems.Where(f => f.Type == FeedItemType.SystemNotification));
     }
 }

--- a/tests/PBA.Infrastructure.Tests/Services/Radar/DigestWriterTests.cs
+++ b/tests/PBA.Infrastructure.Tests/Services/Radar/DigestWriterTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 using PBA.Application.Common.Interfaces;
+using PBA.Domain.Enums;
 using PBA.Infrastructure.Configuration;
 using PBA.Infrastructure.Services.Radar;
 using Xunit;
@@ -66,5 +67,22 @@ public class DigestWriterTests
     {
         var writer = Build("nope", out _);
         Assert.Null(await writer.WriteAsync(Items()));
+    }
+
+    [Theory]
+    [InlineData(DigestKind.Main, "AI news brief")]
+    [InlineData(DigestKind.Microsoft, "Microsoft-ecosystem brief")]
+    public async Task WriteAsync_SelectsSystemPromptForKind(DigestKind kind, string expectedPhrase)
+    {
+        var writer = Build("""{"title":"t","intro":"i","items":[]}""", out var sidecar);
+        string? capturedSystem = null;
+        sidecar.Setup(s => s.SendPromptAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, string?, CancellationToken>((system, _, _, _) => capturedSystem = system)
+            .ReturnsAsync("""{"title":"t","intro":"i","items":[]}""");
+
+        await writer.WriteAsync(Items(), kind);
+
+        Assert.Contains(expectedPhrase, capturedSystem);
     }
 }


### PR DESCRIPTION
## Summary

Brings the 13 commits accumulated on `v2-rebuild` since PR #58 onto `main`. Three feature lines plus infra:

- **External API for project-avatar** — new `/api/external/*` surface (feed, ideas, daily digest, content, website analytics + bounded create-idea), guarded by an `X-Api-Key` endpoint filter with constant-time compare and fail-closed default. Reuses existing MediatR queries; UI endpoints untouched.
- **Microsoft daily brief** — a pure-Microsoft brief alongside the main brief, driven by an `IsMicrosoftSource` flag (by domain, not a hardcoded feed list) and a new `DigestKind`. Two-pane UI + history.
- **Feed-ranking / News Hub** — brand-rank view, labeled Grouped/Ranked toggle, ranked Idea Bank view.
- **Production stack** — Mac Mini compose overlay (nginx web + Production api), pgvector pg17 image, per-host `IDEA_SCORING_ENABLED` gate, embedding input-length cap, nginx CSP relaxed for Google Fonts + feed images, LLM summary HTML sanitized (fixes CSP inline-handler error).
- **DB migrations** — `AddDigestKind`, `AddIsMicrosoftSource`.

## Test plan

- Backend: full API suite green (88 tests in PBA.Api.Tests; 11 new for the external API covering 401 no-key / 401 wrong-key / fail-closed / 200 reads / 201 create). Digest service/writer/query tests added.
- Frontend: news ranked store + digest service/component specs added and passing.
- Live: PBA already running these commits on the Mac Mini (`v2-rebuild` is the deployed branch); `/api/health` and `/api/external/*` verified reachable.

> Note: merging to `main` does not auto-deploy — the Mac Mini runs `v2-rebuild` directly. This keeps `main` as the stable mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)